### PR TITLE
Fix rare potion race condition with forge clients

### DIFF
--- a/BungeeCord-Patches/0041-Fix-potion-race-condition-on-Forge-1.8.9.patch
+++ b/BungeeCord-Patches/0041-Fix-potion-race-condition-on-Forge-1.8.9.patch
@@ -1,0 +1,269 @@
+From 8d698e6607b6687705a9cb38ab541b658a462034 Mon Sep 17 00:00:00 2001
+From: Aaron Hill <aa1ronham@gmail.com>
+Date: Thu, 15 Sep 2016 16:38:37 -0400
+Subject: [PATCH] Fix potion race condition on Forge 1.8.9
+
+
+diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
+index 6f782c8..2d5fc48 100644
+--- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
++++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
+@@ -1,6 +1,8 @@
+ package net.md_5.bungee.protocol;
+ 
+ import net.md_5.bungee.protocol.packet.BossBar;
++import net.md_5.bungee.protocol.packet.EntityEffect;
++import net.md_5.bungee.protocol.packet.EntityRemoveEffect;
+ import net.md_5.bungee.protocol.packet.KeepAlive;
+ import net.md_5.bungee.protocol.packet.ClientSettings;
+ import net.md_5.bungee.protocol.packet.ClientStatus;
+@@ -148,4 +150,13 @@ public abstract class AbstractPacketHandler
+     public void handle(BossBar bossBar) throws Exception
+     {
+     }
++    // Waterfall start
++    public void handle(EntityEffect entityEffect) throws Exception
++    {
++    }
++
++    public void handle(EntityRemoveEffect removeEffect) throws Exception
++    {
++    }
++    // Waterfall end
+ }
+diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+index 4decbb2..796daa3 100644
+--- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
++++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
+@@ -16,6 +16,8 @@ import net.md_5.bungee.protocol.packet.Chat;
+ import net.md_5.bungee.protocol.packet.ClientSettings;
+ import net.md_5.bungee.protocol.packet.EncryptionRequest;
+ import net.md_5.bungee.protocol.packet.EncryptionResponse;
++import net.md_5.bungee.protocol.packet.EntityEffect;
++import net.md_5.bungee.protocol.packet.EntityRemoveEffect;
+ import net.md_5.bungee.protocol.packet.Handshake;
+ import net.md_5.bungee.protocol.packet.KeepAlive;
+ import net.md_5.bungee.protocol.packet.Kick;
+@@ -81,6 +83,18 @@ public enum Protocol
+                     BossBar.class,
+                     map( ProtocolConstants.MINECRAFT_1_9, 0x0C )
+             );
++            // Waterfall start
++            TO_CLIENT.registerPacket(
++                    EntityEffect.class,
++                    map(ProtocolConstants.MINECRAFT_1_8, 0x1D),
++                    map(ProtocolConstants.MINECRAFT_1_9, 0x4B)
++            );
++            TO_CLIENT.registerPacket(
++                    EntityRemoveEffect.class,
++                    map(ProtocolConstants.MINECRAFT_1_8, 0x1E),
++                    map(ProtocolConstants.MINECRAFT_1_9, 0x31)
++            );
++            // Waterfall end
+             TO_CLIENT.registerPacket(
+                     PlayerListItem.class, // PlayerInfo
+                     map( ProtocolConstants.MINECRAFT_1_8, 0x38 ),
+diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/packet/EntityEffect.java b/protocol/src/main/java/net/md_5/bungee/protocol/packet/EntityEffect.java
+new file mode 100644
+index 0000000..d11a9ea
+--- /dev/null
++++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/EntityEffect.java
+@@ -0,0 +1,45 @@
++package net.md_5.bungee.protocol.packet;
++
++import io.netty.buffer.ByteBuf;
++import lombok.AllArgsConstructor;
++import lombok.Data;
++import lombok.EqualsAndHashCode;
++import lombok.NoArgsConstructor;
++import net.md_5.bungee.protocol.AbstractPacketHandler;
++import net.md_5.bungee.protocol.DefinedPacket;
++
++@Data
++@NoArgsConstructor
++@AllArgsConstructor
++@EqualsAndHashCode(callSuper = false)
++public class EntityEffect extends DefinedPacket {
++
++    private int entityId;
++    private int effectId;
++    private int amplifier;
++    private int duration;
++    private boolean hideParticles;
++
++    @Override
++    public void read(ByteBuf buf) {
++        this.entityId = readVarInt(buf);
++        this.effectId = buf.readUnsignedByte();
++        this.amplifier = buf.readUnsignedByte();
++        this.duration = readVarInt(buf);
++        this.hideParticles = buf.readBoolean();
++    }
++
++    @Override
++    public void write(ByteBuf buf) {
++        writeVarInt(this.entityId, buf);
++        buf.writeByte(this.effectId);
++        buf.writeByte(this.amplifier);
++        writeVarInt(this.duration, buf);
++        buf.writeBoolean(this.hideParticles);
++    }
++
++    @Override
++    public void handle(AbstractPacketHandler handler) throws Exception {
++        handler.handle(this);
++    }
++}
+diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/packet/EntityRemoveEffect.java b/protocol/src/main/java/net/md_5/bungee/protocol/packet/EntityRemoveEffect.java
+new file mode 100644
+index 0000000..7ed2dc3
+--- /dev/null
++++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/EntityRemoveEffect.java
+@@ -0,0 +1,36 @@
++package net.md_5.bungee.protocol.packet;
++
++import io.netty.buffer.ByteBuf;
++import lombok.AllArgsConstructor;
++import lombok.Data;
++import lombok.EqualsAndHashCode;
++import lombok.NoArgsConstructor;
++import net.md_5.bungee.protocol.AbstractPacketHandler;
++import net.md_5.bungee.protocol.DefinedPacket;
++
++@Data
++@NoArgsConstructor
++@AllArgsConstructor
++@EqualsAndHashCode(callSuper = false)
++public class EntityRemoveEffect extends DefinedPacket {
++
++    private int entityId;
++    private int effectId;
++
++    @Override
++    public void read(ByteBuf buf) {
++        this.entityId = readVarInt(buf);
++        this.effectId = buf.readUnsignedByte();
++    }
++
++    @Override
++    public void write(ByteBuf buf) {
++        writeVarInt(this.entityId, buf);
++        buf.writeByte(effectId);
++    }
++
++    @Override
++    public void handle(AbstractPacketHandler handler) throws Exception {
++        handler.handle(this);
++    }
++}
+diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+index fead216..f26d20c 100644
+--- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
++++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
+@@ -2,7 +2,9 @@ package net.md_5.bungee;
+ 
+ import com.google.common.base.Objects;
+ import com.google.common.base.Preconditions;
++import com.google.common.collect.HashMultimap;
+ import com.google.common.collect.ImmutableMap;
++import com.google.common.collect.Multimap;
+ import io.netty.bootstrap.Bootstrap;
+ import io.netty.channel.Channel;
+ import io.netty.channel.ChannelFuture;
+@@ -131,6 +133,10 @@ public final class UserConnection implements ProxiedPlayer
+     private final Scoreboard serverSentScoreboard = new Scoreboard();
+     @Getter
+     private final Collection<UUID> sentBossBars = new HashSet<>();
++    // Waterfall start
++    @Getter
++    private final Multimap<Integer, Integer> potions = HashMultimap.create();
++    // Waterfall end
+     /*========================================================================*/
+     @Getter
+     private String displayName;
+diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+index 4177ef5..9618d10 100644
+--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
++++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+@@ -31,6 +31,8 @@ import net.md_5.bungee.netty.PacketHandler;
+ import net.md_5.bungee.protocol.DefinedPacket;
+ import net.md_5.bungee.protocol.PacketWrapper;
+ import net.md_5.bungee.protocol.packet.BossBar;
++import net.md_5.bungee.protocol.packet.EntityEffect;
++import net.md_5.bungee.protocol.packet.EntityRemoveEffect;
+ import net.md_5.bungee.protocol.packet.KeepAlive;
+ import net.md_5.bungee.protocol.packet.PlayerListItem;
+ import net.md_5.bungee.protocol.packet.ScoreboardObjective;
+@@ -519,6 +521,32 @@ public class DownstreamBridge extends PacketHandler
+         }
+     }
+ 
++    // Waterfall start
++    @Override
++    public void handle(EntityEffect entityEffect) throws Exception
++    {
++        // Don't send any potions when switching between servers (which involves a handshake), which can trigger a race
++        // condition on the client.
++        if (this.con.getForgeClientHandler().isForgeUser() && !this.con.getForgeClientHandler().isHandshakeComplete()) {
++            throw CancelSendSignal.INSTANCE;
++        }
++        con.getPotions().put(rewriteEntityId(entityEffect.getEntityId()), entityEffect.getEffectId());
++    }
++
++    @Override
++    public void handle(EntityRemoveEffect removeEffect) throws Exception
++    {
++        con.getPotions().remove(rewriteEntityId(removeEffect.getEntityId()), removeEffect.getEffectId());
++    }
++
++    private int rewriteEntityId(int entityId) {
++        if (entityId == con.getServerEntityId()) {
++            return con.getClientEntityId();
++        }
++        return entityId;
++    }
++    // Waterfall end
++
+     @Override
+     public String toString()
+     {
+diff --git a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
+index 314fd43..3367349 100644
+--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
++++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java
+@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
+ import lombok.Setter;
+ import net.md_5.bungee.BungeeCord;
+ import net.md_5.bungee.UserConnection;
++import net.md_5.bungee.protocol.ProtocolConstants;
++import net.md_5.bungee.protocol.packet.EntityRemoveEffect;
+ import net.md_5.bungee.protocol.packet.PluginMessage;
+ 
+ /**
+@@ -91,9 +93,23 @@ public class ForgeClientHandler
+     public void resetHandshake()
+     {
+         state = ForgeClientHandshakeState.HELLO;
++
++        // This issue only exists in Forge 1.8.9
++        if (this.con.getPendingConnection().getVersion() == ProtocolConstants.MINECRAFT_1_8) {
++            this.resetAllThePotions(con);
++        }
++
+         con.unsafe().sendPacket( ForgeConstants.FML_RESET_HANDSHAKE );
+     }
+ 
++    private void resetAllThePotions(UserConnection con) {
++        // Just to be sure
++        for (Map.Entry<Integer, Integer> entry: con.getPotions().entries()) {
++            con.unsafe().sendPacket(new EntityRemoveEffect(entry.getKey(), entry.getValue()));
++        }
++        con.getPotions().clear();
++    }
++
+     /**
+      * Sends the server mod list to the client, or stores it for sending later.
+      *
+-- 
+2.9.3
+


### PR DESCRIPTION
Tl;dr: This PR fixes a rare race condition which causes Forge clients to crash when switching between servers.

**Background**

When a Forge client connects to a Forge server, the client and server perform a special handshake before continuing with the login process. During this handshake, the server and client exchange their respective mod lists (disconnecting if a mod is missing on either side). They also exchange [registry information](https://github.com/MinecraftForge/MinecraftForge/blob/6e90348/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java#L105), which includes blocks, items, and potions.

Normally, this handshake is performed only once - when a player initially connects to a server (e.g. opening a singleplayer world, or connceting to a server from the 'Multiplayer' screen). However, with Waterfall/Bungeecord, players can switch between different Forge servers, each having distinct mod lists and registry data. To facilitate this, Forge allows a [special reset packet](https://github.com/MinecraftForge/MinecraftForge/blob/6e90348/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java#L159) to be sent. This resets the handshake process to its initial state, allowing it to be re-performed by the server the player is switching to. Accordingly, Waterfall/Bungeecord [sends this packet](https://github.com/SpigotMC/BungeeCord/blob/aaddc9fcfdcada8d19ab115f2dcc8aed413a9206/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandler.java#L91) when switching a Forge client to a Forge server.

However, there is a critical difference between the intiial handshake performed when a client first joins, and any handshakes performed after a reset packet is sent. The former handshakes take place right at the start of the connetion, becfore the client has joined the world. Because of this, `WorldClient` has not been instantiated yet, and thus cannot interact with the registry (more on this later). Any handshakes initiated by reset packets, however, are performed while the player is still in the world! This has the advantage of allowing the player to be rejected by the target server (if the client is missing a required mod of the new server, for example), without the need to first respawn them or switch their dimension (as is done during an actual successful transfer). However, this means that while the handshake is taking place, the client world is still running and ticking. This leads to the issue described below.

**The issue**

Because the secondary handshake is happening in parallel (specifically, on a Netty thread) with the main game execution (on the main thread), race conditions have the potential to occur. Fortunately, while the handshaking process can cause some temporary odd behavior (the player falling through the ground while the block registry is being rebuilt), it doesn't result in crashes - with one notable exception.

When the client starts to load registry data from the server, it first [clears out the `Potion.potionTypes`](https://github.com/MinecraftForge/MinecraftForge/blob/6e90348dc546164b21735aefd83ed0bac0d8283c/src/main/java/net/minecraftforge/fml/common/registry/PersistentRegistryManager.java#L156) array. Normally, this is fine, since the client world doesn't yet exist. However, during a reset-triggered handshake, the client world is still ticking entities - importantly, entity potion effects. If the client happens to tick an entity after `Potion.potionTypes` is cleared out, but before it's filled back in with data from the server, the client will crash:

```
java.lang.NullPointerException: Ticking entity
    at net.minecraft.potion.PotionEffect.func_76455_a(PotionEffect.java:113)
    at net.minecraft.entity.EntityLivingBase.func_70679_bo(EntityLivingBase.java:517)
    at net.minecraft.entity.EntityLivingBase.func_70030_z(EntityLivingBase.java:300)
    at net.minecraft.entity.Entity.func_70071_h_(Entity.java:279)
    at net.minecraft.entity.EntityLivingBase.func_70071_h_(EntityLivingBase.java:1564)
    at net.minecraft.entity.player.EntityPlayer.func_70071_h_(EntityPlayer.java:283)
    at net.minecraft.client.entity.EntityPlayerSP.func_70071_h_(EntityPlayerSP.java:117)
    at net.minecraft.world.World.func_72866_a(World.java:1862)
    at net.minecraft.world.World.func_72870_g(World.java:1831)
    at net.minecraft.world.World.func_72939_s(World.java:1663)
    at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:2089)
    at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1024)
    at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:349)
    at net.minecraft.client.main.Main.main(SourceFile:124)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)

```

The following code snippet, from `PotionEffect#onUpdate`, shows why:

```
if (Potion.potionTypes[this.potionID].isReady(this.duration, this.amplifier))
```

When the race condition occurs, all elements in `Potion.potionTypes` will be null, causing an NPE. This happens very infrequently, since there's only a small window of time - specifically, within [PersistentRegistryManager.injectSnapshot](https://github.com/MinecraftForge/MinecraftForge/blob/6e90348dc546164b21735aefd83ed0bac0d8283c/src/main/java/net/minecraftforge/fml/common/registry/PersistentRegistryManager.java#L143) - during which ticking an entity's potion effect will cause the crash.

**Reproducing**

Since this is a race condition, it can be difficult to reproduce through normal means. The best way to reproduce it is through a breakpoint in an IDE. Done correctly, this can reproduce the issue 100% of the time.

Steps to reproduce:
1. Setup a Waterfall/Bungeecord instance, with two forge servers connected to it.
2. Start a Forge 1.8.9 client with a debugger connected. This can be done through the `GradleStart` class in a forge mod workspace, or by specifying the necessary arguments in the profile settings of your minecraft client.
3. Give yourself, or any entity on the server, any potion effect (preferrably with a long duration, so that it won't expire while you're trying to switch servers).
4. Set a breakpoint on [this line of PersistentRegistryManager](https://github.com/MinecraftForge/MinecraftForge/blob/d06e0ad71b8471923cc809dde58251de8299a143/src/main/java/net/minecraftforge/fml/common/registry/PersistentRegistryManager.java#L159) in your IDE. **IMPORTANT**: This breakpoint _must_ be set to only suspend the thread it's in, rather than all threads. This simulates an arbitrarily long execution time of that method (as well as the Netty thread that it's called from).
5. Attempt to connect to the other Forge server in the network. The client should crash almost immediately, provided that the breakpoint is set correctly.

**The fix**

Fixing this issue turns out to be farily simple. It consists of two parts:
- Removing all potion effects from the client's world (on all entities) before performing the handshake
- Supressing any new potion packets sent during the handshake

The first part is accomplished by keeping track of all potion effects on a client. This is done by listening for `Entity Effect` and `Remove Entity Effect` packets, and adding/removing mappings from entity ids to potion ids as necessasry. When the client switches to a Forge server, `Remove Entity Effect` packets are sent to the client for each mapping stored. Since this is done before the handshake packet is even sent, it guarantees that no potions are present on the client when the handshake begins.

The second part is accomplished by blocking all potion packets sent from the server while the handshake is in process. During testing, it was discovered that the first part alone was not necessary to stop all crashes. Rarely, the old server (the one being switched away from) may send a potion packet to the client at just the right time during the handshake, so as to trigger ticking a potion while 
`Potion.potionTypes` is cleared out. By temporarily blocking potion packets, we ensure that no potions are present on the client for the duration of the handshake.

**FAQs**

_Why not fix this on Forge's side?_

Due to changes made in 1.9 and 1.10 to how potions are registered, this issue only affects 1.8.9, which Forge is no longer accepting PR's for. Additionally, fixing the issue in Forge would require substantial modifications, in order to move handshaking logic to the main thread when the player is already in game.

_Can't you just remove all possible potions ids from the client, instead of keeping track of which ones need to be removed?_

While this approach is appealing, it would have to be done for _every_ entity present on the client, in order to ensure that the race condition cannot occur. Since Forge bumps the maximum number of potions from 32 to 256, this would require sending `256 * n` packets, where n is the total number of entities on the client. On a popular server with 30 or 40 players, this would require sending literally thousands of almost entirely useless packets every time a forge player switched servers. Additionally, it would require keeping track of which entities are present on each client, which has basically the same overhead as keeping track of potions.

_Why would you write this gigantic wall of text for an issue that's pretty simple to fix?_

While the probabilty of this issue occuring during any individual server switch is very low, popular servers can have 30-40 people on at a time, with each person switching servers many times throughout the day. This virtually guarantees that the issue will come up at least a few times. Several different servers that I've heard of have had this issue, which creates a constant headache for server owners who can't figure out how to stop a small percentage of their users from crashing.

Since I couldn't find anyone who'd found a solution to this issue, this PR description servers as a reference for anyone having trouble with the issue. This includes people running proxy software other than Waterfall (e.g. a custom BungeeCord build), who may want to implement the fix themselves.
