### PR TITLE
Migrate more micro-optimisations from Waterfall-Old

### DIFF
--- a/BungeeCord-Patches/0011-Optimize-uuid-conversions.patch
+++ b/BungeeCord-Patches/0011-Optimize-uuid-conversions.patch
@@ -1,4 +1,4 @@
-From 2e226193aef5c311a2538f289bc9c998ea3aeb3e Mon Sep 17 00:00:00 2001
+From 59f7e0021b2116919e0b3b8a2fba1a005a6640b6 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Mon, 14 Mar 2016 15:40:44 -0700
 Subject: [PATCH] Optimize uuid conversions
@@ -8,7 +8,7 @@ Manually decode uuids to and from hex.
 
 diff --git a/api/src/main/java/io/github/waterfallmc/waterfall/utils/Hex.java b/api/src/main/java/io/github/waterfallmc/waterfall/utils/Hex.java
 new file mode 100644
-index 0000000..ece5f79
+index 00000000..ece5f798
 --- /dev/null
 +++ b/api/src/main/java/io/github/waterfallmc/waterfall/utils/Hex.java
 @@ -0,0 +1,113 @@
@@ -128,10 +128,10 @@ index 0000000..ece5f79
 \ No newline at end of file
 diff --git a/api/src/main/java/io/github/waterfallmc/waterfall/utils/UUIDUtils.java b/api/src/main/java/io/github/waterfallmc/waterfall/utils/UUIDUtils.java
 new file mode 100644
-index 0000000..7258a26
+index 00000000..cc24dd35
 --- /dev/null
 +++ b/api/src/main/java/io/github/waterfallmc/waterfall/utils/UUIDUtils.java
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,74 @@
 +package io.github.waterfallmc.waterfall.utils;
 +import java.util.UUID;
 +
@@ -141,6 +141,10 @@ index 0000000..7258a26
 +public class UUIDUtils {
 +    private UUIDUtils() {}
 +
++    public static String undash(String id) {
++        return new StringBuilder( 32 ).append( id, 0, 8 ).append( id, 9, 13 ).append( id, 14, 18 ).append( id, 19, 23 ).append( id, 24, 36 ).toString();
++    }
++
 +    public static String toMojangString(UUID id) {
 +        Preconditions.checkNotNull(id, "Null id");
 +        return Hex.encodeString(toBytes(id));
@@ -149,7 +153,7 @@ index 0000000..7258a26
 +    public static UUID fromString(String s) {
 +        Preconditions.checkNotNull(s, "Null string");
 +        if (s.length() == 36) { // UUID.toString() uuid
-+            s = s.replaceAll("-", "");
++            s = UUIDUtils.undash(s);
 +        } else if (s.length() != 32) {
 +            throw new IllegalArgumentException("Invalid UUID: " + s);
 +        }
@@ -204,7 +208,7 @@ index 0000000..7258a26
 +}
 \ No newline at end of file
 diff --git a/api/src/main/java/net/md_5/bungee/Util.java b/api/src/main/java/net/md_5/bungee/Util.java
-index 86a0055..6c9c6d6 100644
+index 86a00555..6c9c6d61 100644
 --- a/api/src/main/java/net/md_5/bungee/Util.java
 +++ b/api/src/main/java/net/md_5/bungee/Util.java
 @@ -1,11 +1,15 @@
@@ -240,6 +244,48 @@ index 86a0055..6c9c6d6 100644
 +        return UUIDUtils.fromString(uuid);
      }
  }
+diff --git a/api/src/main/java/net/md_5/bungee/api/ServerPing.java b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+index 27b51849..5320ae0b 100644
+--- a/api/src/main/java/net/md_5/bungee/api/ServerPing.java
++++ b/api/src/main/java/net/md_5/bungee/api/ServerPing.java
+@@ -3,6 +3,7 @@ package net.md_5.bungee.api;
+ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.UUID;
++
+ import lombok.AllArgsConstructor;
+ import lombok.Data;
+ import lombok.Getter;
+@@ -75,7 +76,7 @@ public class ServerPing
+ 
+         public String getId()
+         {
+-            return uniqueId.toString().replaceAll( "-", "" );
++            return io.github.waterfallmc.waterfall.utils.UUIDUtils.undash( uniqueId.toString() ); // Waterfall
+         }
+     }
+ 
+diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+index d87b03c0..e0b77838 100644
+--- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
++++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
+@@ -12,6 +12,7 @@ import java.util.UUID;
+ import java.util.concurrent.TimeUnit;
+ import java.util.logging.Level;
+ import javax.crypto.SecretKey;
++
+ import lombok.Getter;
+ import lombok.RequiredArgsConstructor;
+ import net.md_5.bungee.BungeeCord;
+@@ -603,7 +604,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+     @Override
+     public String getUUID()
+     {
+-        return uniqueId.toString().replaceAll( "-", "" );
++        return io.github.waterfallmc.waterfall.utils.UUIDUtils.undash( uniqueId.toString() ); // Waterfall
+     }
+ 
+     @Override
 -- 
-2.8.3
+2.11.0.windows.1
 

--- a/BungeeCord-Patches/0017-Micro-optimizations.patch
+++ b/BungeeCord-Patches/0017-Micro-optimizations.patch
@@ -1,13 +1,16 @@
-From 81c109310e7da6e5ab30701bed7a68ec409cc504 Mon Sep 17 00:00:00 2001
+From 172b1feaee98c58f898bb3bf5abd7ebaf5f0fcb7 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 18:05:33 -0600
 Subject: [PATCH] Micro-optimizations
 
 - PluginManager.dispatchCommand() avoids regex while splitting commands. Java 7 introduced an optimized String.split() that should be used instead (affects command dispatch).
 - Avoid regex in getLocale() by changing from replaceAll(String, String) to replaceAll(char, char)
+- Don't attempt to format arguments when there are none provided
+- Don't create a data input stream for every plugin message we get from servers
+- Optimise replacing dashes in UUID's
 
 diff --git a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
-index 71a5a15..520ee31 100644
+index 71a5a158..520ee315 100644
 --- a/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
 +++ b/api/src/main/java/net/md_5/bungee/api/plugin/PluginManager.java
 @@ -42,7 +42,6 @@ import org.yaml.snakeyaml.introspector.PropertyUtils;
@@ -27,8 +30,23 @@ index 71a5a15..520ee31 100644
          // Check for chat that only contains " "
          if ( split.length == 0 )
          {
+diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+index a0f2c55a..ac272720 100644
+--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
++++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+@@ -480,7 +480,9 @@ public class BungeeCord extends ProxyServer
+         String translation = "<translation '" + name + "' missing>";
+         try
+         {
+-            translation = MessageFormat.format( customBundle != null && customBundle.containsKey( name ) ? customBundle.getString( name ) : baseBundle.getString( name ), args );
++            final String string = customBundle != null && customBundle.containsKey( name ) ? customBundle.getString( name ) : baseBundle.getString( name );
++
++            translation = ( args.length == 0 ) ? string : MessageFormat.format( string, args );
+         } catch ( MissingResourceException ex )
+         {
+         }
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index e10ea44..5b02c5f 100644
+index 721d48a9..812d9379 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 @@ -556,7 +556,7 @@ public final class UserConnection implements ProxiedPlayer
@@ -40,6 +58,26 @@ index e10ea44..5b02c5f 100644
      }
  
      @Override
+diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+index c0a5061a..ce32f6b1 100644
+--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
++++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+@@ -222,7 +222,6 @@ public class DownstreamBridge extends PacketHandler
+     @Override
+     public void handle(PluginMessage pluginMessage) throws Exception
+     {
+-        DataInput in = pluginMessage.getStream();
+         PluginMessageEvent event = new PluginMessageEvent( con.getServer(), con, pluginMessage.getTag(), pluginMessage.getData().clone() );
+ 
+         if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
+@@ -249,6 +248,7 @@ public class DownstreamBridge extends PacketHandler
+ 
+         if ( pluginMessage.getTag().equals( "BungeeCord" ) )
+         {
++            DataInput in = pluginMessage.getStream();
+             ByteArrayDataOutput out = ByteStreams.newDataOutput();
+             String subChannel = in.readUTF();
+ 
 -- 
-2.10.2
+2.11.0.windows.1
 

--- a/BungeeCord-Patches/0022-Optional-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0022-Optional-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From bb21405720f79a011d0d0c67cc9ce40d63739ddc Mon Sep 17 00:00:00 2001
+From 7665abb83cc9c5291e61924a47118bdfc18fc821 Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Optional server list ping logging.
@@ -9,7 +9,7 @@ This avoids spamming the logs with connection notices.
 Server list pings are only logged if the log_server_list_pings config.yml option is true, defaults to false
 
 diff --git a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
-index 66d0b8a..5a49050 100644
+index 66d0b8a1..5a49050a 100644
 --- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
 +++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
 @@ -89,6 +89,11 @@ public interface ProxyConfig
@@ -25,7 +25,7 @@ index 66d0b8a..5a49050 100644
  
      /**
 diff --git a/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java b/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java
-index e56d359..68f2546 100644
+index e56d3591..68f25460 100644
 --- a/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java
 +++ b/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java
 @@ -16,6 +16,13 @@ public class WaterfallConfiguration extends Configuration {
@@ -61,7 +61,7 @@ index e56d359..68f2546 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index ed057b8..a37f3ea 100644
+index ed057b8a..a37f3ea3 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -382,6 +382,6 @@ public class ServerConnector extends PacketHandler
@@ -73,7 +73,7 @@ index ed057b8..a37f3ea 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index c0a5061..4768cb4 100644
+index ce32f6b1..470f0bef 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 @@ -510,6 +510,6 @@ public class DownstreamBridge extends PacketHandler
@@ -85,10 +85,10 @@ index c0a5061..4768cb4 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index bdcbdb7..d14d893 100644
+index e0b77838..f11643ab 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -281,19 +281,22 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -282,19 +282,22 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          }
  
          this.virtualHost = InetSocketAddress.createUnresolved( handshake.getHost(), handshake.getPort() );
@@ -112,7 +112,7 @@ index bdcbdb7..d14d893 100644
                  thisState = State.USERNAME;
                  ch.setProtocol( Protocol.LOGIN );
  
-@@ -609,7 +612,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -610,7 +613,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      @Override
      public String toString()
      {
@@ -122,7 +122,7 @@ index bdcbdb7..d14d893 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 654be21..618e76e 100644
+index 654be214..618e76e3 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 @@ -213,6 +213,6 @@ public class UpstreamBridge extends PacketHandler
@@ -134,5 +134,5 @@ index 654be21..618e76e 100644
      }
  }
 -- 
-2.10.0
+2.11.0.windows.1
 

--- a/BungeeCord-Patches/0024-Add-a-property-to-accept-invalid-ping-packets.patch
+++ b/BungeeCord-Patches/0024-Add-a-property-to-accept-invalid-ping-packets.patch
@@ -1,4 +1,4 @@
-From f20d4b5a44265e1ded78a203333870e962075975 Mon Sep 17 00:00:00 2001
+From a0648fde5463784940996efbce228a5fa1736173 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Sun, 7 Feb 2016 00:01:19 -0700
 Subject: [PATCH] Add a property to accept invalid ping packets
@@ -9,10 +9,10 @@ You can enable it by setting '-Dwaterfall.acceptInvalidPackets=true' at the comm
 Fixes #23
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index d14d893..61158d5 100644
+index f11643ab..c7de8fa4 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -247,10 +247,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -248,10 +248,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          thisState = State.PING;
      }
  
@@ -29,5 +29,5 @@ index d14d893..61158d5 100644
          disconnect( "" );
      }
 -- 
-2.7.4 (Apple Git-66)
+2.11.0.windows.1
 

--- a/BungeeCord-Patches/0032-Add-dynamic-server-addition-removal-api.patch
+++ b/BungeeCord-Patches/0032-Add-dynamic-server-addition-removal-api.patch
@@ -1,4 +1,4 @@
-From 8d4ebbcc8999f166b3a9e7174ffb654a56cd3a2d Mon Sep 17 00:00:00 2001
+From af9943d555d07bc98a381d8ca661181b7f7696d0 Mon Sep 17 00:00:00 2001
 From: Troy Frew <fuzzy_bot@arenaga.me>
 Date: Wed, 29 Jun 2016 04:29:25 +0200
 Subject: [PATCH] Add dynamic server addition/removal api.
@@ -8,7 +8,7 @@ The provided methods will not move a player if a server is removed or the server
 Thanks to Overcast for the idea
 
 diff --git a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
-index 5a49050..f04e2bf 100644
+index 5a49050a..f04e2bf4 100644
 --- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
 +++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
 @@ -32,9 +32,83 @@ public interface ProxyConfig
@@ -96,7 +96,7 @@ index 5a49050..f04e2bf 100644
       * Does the server authenticate with mojang
       */
 diff --git a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
-index 11c5b68..1c011d0 100644
+index 11c5b685..1c011d08 100644
 --- a/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
 +++ b/api/src/main/java/net/md_5/bungee/api/ProxyServer.java
 @@ -93,9 +93,25 @@ public abstract class ProxyServer
@@ -126,7 +126,7 @@ index 11c5b68..1c011d0 100644
       * Gets the server info of a server.
       *
 diff --git a/config/src/main/java/net/md_5/bungee/config/Configuration.java b/config/src/main/java/net/md_5/bungee/config/Configuration.java
-index 967a1b2..08aa698 100644
+index 967a1b2a..08aa6981 100644
 --- a/config/src/main/java/net/md_5/bungee/config/Configuration.java
 +++ b/config/src/main/java/net/md_5/bungee/config/Configuration.java
 @@ -44,6 +44,13 @@ public final class Configuration
@@ -144,10 +144,10 @@ index 967a1b2..08aa698 100644
      {
          int index = path.indexOf( SEPARATOR );
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 60a0cb4..f04e9c1 100644
+index c227396f..f392a281 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -563,10 +563,18 @@ public class BungeeCord extends ProxyServer
+@@ -565,10 +565,18 @@ public class BungeeCord extends ProxyServer
          return config.getServers();
      }
  
@@ -168,7 +168,7 @@ index 60a0cb4..f04e9c1 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
-index db9ebbd..4d16fa3 100644
+index db9ebbdd..4d16fa3a 100644
 --- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
 +++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
 @@ -1,6 +1,7 @@
@@ -285,5 +285,5 @@ index db9ebbd..4d16fa3 100644
 +    // Waterfall end
  }
 -- 
-2.10.0
+2.11.0.windows.1
 

--- a/BungeeCord-Patches/0033-Don-t-send-KICK-packets-while-in-HANDSHAKE-state.patch
+++ b/BungeeCord-Patches/0033-Don-t-send-KICK-packets-while-in-HANDSHAKE-state.patch
@@ -1,14 +1,14 @@
-From b3e9c9b6ba4a0bba0e697782a5412499909216dd Mon Sep 17 00:00:00 2001
+From e1616d2c0ed2af4e84417cbcce68ba0b3609c74c Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Mon, 6 Jun 2016 13:36:10 -0600
 Subject: [PATCH] Don't send KICK packets while in HANDSHAKE state
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index bbad8dd..6ba098a 100644
+index c7de8fa4..9a2c94bb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -551,7 +551,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -552,7 +552,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
              @Override
              public void run()
              {
@@ -18,5 +18,5 @@ index bbad8dd..6ba098a 100644
                      unsafe().sendPacket( new Kick( ComponentSerializer.toString( reason ) ) );
                  }
 -- 
-2.10.0
+2.11.0.windows.1
 

--- a/BungeeCord-Patches/0035-Configurable-server-version-in-ping-response.patch
+++ b/BungeeCord-Patches/0035-Configurable-server-version-in-ping-response.patch
@@ -1,11 +1,11 @@
-From ef40f84049f7b8e335ca901484d48940b1894b56 Mon Sep 17 00:00:00 2001
+From 991054ce0e216db5a84832d9f2f7c26566b2fc49 Mon Sep 17 00:00:00 2001
 From: Troy Frew <fuzzy_bot@arenaga.me>
 Date: Wed, 29 Jun 2016 13:56:57 -0500
 Subject: [PATCH] Configurable server version in ping response
 
 
 diff --git a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
-index f04e2bf..a443614 100644
+index f04e2bf4..a4436141 100644
 --- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
 +++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
 @@ -168,6 +168,11 @@ public interface ProxyConfig
@@ -21,7 +21,7 @@ index f04e2bf..a443614 100644
  
      /**
 diff --git a/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java b/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java
-index 68f2546..5983581 100644
+index 68f25460..59835815 100644
 --- a/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java
 +++ b/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java
 @@ -4,8 +4,11 @@ import lombok.*;
@@ -59,10 +59,10 @@ index 68f2546..5983581 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 239027d..2f8b16f 100644
+index f392a281..4a33b9de 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -612,7 +612,7 @@ public class BungeeCord extends ProxyServer
+@@ -614,7 +614,7 @@ public class BungeeCord extends ProxyServer
      @Override
      public String getGameVersion()
      {
@@ -72,5 +72,5 @@ index 239027d..2f8b16f 100644
  
      @Override
 -- 
-2.10.0
+2.11.0.windows.1
 


### PR DESCRIPTION
- Don't attempt to format arguments when there are none provided (-Mystiflow)
- Don't create a data input stream for every plugin message we get from servers  (-minecrafter)
- Optimize UUID dash replacements (-minecrafter)