### PR TITLE
Use correct packet ids for 1.12-pre2

### DIFF
--- a/BungeeCord-Patches/0039-Fix-potion-race-condition-on-Forge-1.8.9.patch
+++ b/BungeeCord-Patches/0039-Fix-potion-race-condition-on-Forge-1.8.9.patch
@@ -1,6 +1,6 @@
-From 8ba224224c6c0c0701224baea319e6f1e9bd5cd7 Mon Sep 17 00:00:00 2001
+From 8faa93de2ad9295f92d53da48e907cfd10aa8f6f Mon Sep 17 00:00:00 2001
 From: Aaron Hill <aa1ronham@gmail.com>
-Date: Thu, 15 Sep 2016 16:38:37 -0400
+Date: Thu, 15 Sep 2016 22:38:37 +0200
 Subject: [PATCH] Fix potion race condition on Forge 1.8.9
 
 
@@ -32,7 +32,7 @@ index 6f782c8f..2d5fc487 100644
 +    // Waterfall end
  }
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-index 5636e67c..abc5b535 100644
+index a7036833..c59006d6 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 @@ -16,6 +16,8 @@ import net.md_5.bungee.protocol.packet.Chat;
@@ -44,7 +44,7 @@ index 5636e67c..abc5b535 100644
  import net.md_5.bungee.protocol.packet.Handshake;
  import net.md_5.bungee.protocol.packet.KeepAlive;
  import net.md_5.bungee.protocol.packet.Kick;
-@@ -86,6 +88,21 @@ public enum Protocol
+@@ -86,6 +88,22 @@ public enum Protocol
                      map( ProtocolConstants.MINECRAFT_1_9, 0x0C ),
                      map( ProtocolConstants.MINECRAFT_1_12, 0x0D )
              );
@@ -54,13 +54,14 @@ index 5636e67c..abc5b535 100644
 +                    map(ProtocolConstants.MINECRAFT_1_8, 0x1D),
 +                    map(ProtocolConstants.MINECRAFT_1_9, 0x4C),
 +                    map(ProtocolConstants.MINECRAFT_1_9_4, 0x4B),
-+                    map(ProtocolConstants.MINECRAFT_1_10, 0x4B)
-+
++                    map(ProtocolConstants.MINECRAFT_1_10, 0x4B),
++                    map(ProtocolConstants.MINECRAFT_1_12, 0x4D)
 +            );
 +            TO_CLIENT.registerPacket(
 +                    EntityRemoveEffect.class,
 +                    map(ProtocolConstants.MINECRAFT_1_8, 0x1E),
-+                    map(ProtocolConstants.MINECRAFT_1_9, 0x31)
++                    map(ProtocolConstants.MINECRAFT_1_9, 0x31),
++                    map(ProtocolConstants.MINECRAFT_1_12, 0x33)
 +            );
 +            // Waterfall end
              TO_CLIENT.registerPacket(
@@ -268,5 +269,5 @@ index 673497e5..17e250d4 100644
       * Sends the server mod list to the client, or stores it for sending later.
       *
 -- 
-2.12.0
+2.13.0.windows.1
 


### PR DESCRIPTION
Waterfall registers some packets on it's own which needs to be updated.