### PR TITLE
Use correct packet ids for 1.12-pre5

### DIFF
--- a/BungeeCord-Patches/0039-Fix-potion-race-condition-on-Forge-1.8.9.patch
+++ b/BungeeCord-Patches/0039-Fix-potion-race-condition-on-Forge-1.8.9.patch
@@ -1,4 +1,4 @@
-From b0d889f9e4b93671ec5999b6c89b2a39155bf6ae Mon Sep 17 00:00:00 2001
+From 7b94bf37323209f817606573449e0c52ed04f7e9 Mon Sep 17 00:00:00 2001
 From: Aaron Hill <aa1ronham@gmail.com>
 Date: Thu, 15 Sep 2016 22:38:37 +0200
 Subject: [PATCH] Fix potion race condition on Forge 1.8.9
@@ -32,7 +32,7 @@ index 6f782c8f..2d5fc487 100644
 +    // Waterfall end
  }
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-index a2eeb024..d6d278c9 100644
+index a2eeb024..18c99076 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 @@ -16,6 +16,8 @@ import net.md_5.bungee.protocol.packet.Chat;
@@ -55,13 +55,13 @@ index a2eeb024..d6d278c9 100644
 +                    map(ProtocolConstants.MINECRAFT_1_9, 0x4C),
 +                    map(ProtocolConstants.MINECRAFT_1_9_4, 0x4B),
 +                    map(ProtocolConstants.MINECRAFT_1_10, 0x4B),
-+                    map(ProtocolConstants.MINECRAFT_1_12, 0x4D)
++                    map(ProtocolConstants.MINECRAFT_1_12, 0x4E)
 +            );
 +            TO_CLIENT.registerPacket(
 +                    EntityRemoveEffect.class,
 +                    map(ProtocolConstants.MINECRAFT_1_8, 0x1E),
 +                    map(ProtocolConstants.MINECRAFT_1_9, 0x31),
-+                    map(ProtocolConstants.MINECRAFT_1_12, 0x33)
++                    map(ProtocolConstants.MINECRAFT_1_12, 0x32)
 +            );
 +            // Waterfall end
              TO_CLIENT.registerPacket(
@@ -269,5 +269,5 @@ index 673497e5..17e250d4 100644
       * Sends the server mod list to the client, or stores it for sending later.
       *
 -- 
-2.13.0
+2.13.0.windows.1
 


### PR DESCRIPTION
Please note that there is a PR for wrong packet IDs waiting upstream, too:
https://github.com/SpigotMC/BungeeCord/pull/2143