### PR TITLE
Fix some forge plugin message packets not being forwarded correctly

### DIFF
--- a/BungeeCord-Patches/0043-Fix-some-forge-plugin-message-packets-not-being-forw.patch
+++ b/BungeeCord-Patches/0043-Fix-some-forge-plugin-message-packets-not-being-forw.patch
@@ -1,0 +1,59 @@
+From eb1a75325f83a7eabb72d503f6438fecd65bfd98 Mon Sep 17 00:00:00 2001
+From: Daniel Naylor <git@drnaylor.co.uk>
+Date: Mon, 17 Jul 2017 20:24:17 +0100
+Subject: [PATCH] Fix some forge plugin message packets not being forwarded
+ correctly
+
+This fixes #155, see SpongePowered/SpongeForge#1507
+
+diff --git a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
+index 52429265..5e02f8c8 100644
+--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
++++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeClientHandshakeState.java
+@@ -171,7 +171,8 @@ enum ForgeClientHandshakeState implements IForgeClientPacketHandler<ForgeClientH
+         public ForgeClientHandshakeState handle(PluginMessage message, UserConnection con)
+         {
+             // Ack.
+-            if ( message.getData()[0] == -1 )
++            if (( message.getTag().equals( ForgeConstants.FML_HANDSHAKE_TAG ) && message.getData()[0] == -1 )
++                    || message.getTag().equals( ForgeConstants.FORGE_REGISTER ))
+             {
+                 ForgeLogger.logClient( ForgeLogger.LogDirection.RECEIVED, this.name(), message );
+                 con.unsafe().sendPacket( message );
+@@ -187,7 +188,7 @@ enum ForgeClientHandshakeState implements IForgeClientPacketHandler<ForgeClientH
+         }
+     },
+     /**
+-     * Handshake has been completed. Ignores any future handshake packets.
++     * Handshake has been completed. Ignores any future handshake packets, but not any FORGE packets.
+      */
+     DONE
+     {
+@@ -196,6 +197,11 @@ enum ForgeClientHandshakeState implements IForgeClientPacketHandler<ForgeClientH
+         public ForgeClientHandshakeState handle(PluginMessage message, UserConnection con)
+         {
+             ForgeLogger.logClient( ForgeLogger.LogDirection.RECEIVED, this.name(), message );
++            if ( message.getTag().equals( ForgeConstants.FORGE_REGISTER ))
++            {
++                con.unsafe().sendPacket( message );
++            }
++
+             return this;
+         }
+ 
+diff --git a/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java b/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
+index 3fe5ec5f..a0c07874 100644
+--- a/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
++++ b/proxy/src/main/java/net/md_5/bungee/forge/ForgeServerHandler.java
+@@ -51,7 +51,7 @@ public class ForgeServerHandler
+         ForgeServerHandshakeState prevState = state;
+         packetQueue.add( message );
+         state = state.send( message, con );
+-        if ( state != prevState ) // send packets
++        if ( state == ForgeServerHandshakeState.DONE || state != prevState ) // send packets
+         {
+             synchronized ( packetQueue )
+             {
+-- 
+2.11.0
+


### PR DESCRIPTION
There was an issue where the Register Dimension packet was not being sent from Waterfall, as the code that handled the FML handshake blocked all packets from being sent on once the handshake was deemed to be complete. This prevented Forge clients from logging into worlds where the dimension ID was not a vanilla one - they just hung on the logging in phase (with exceptions being spammed in the client log).

This fix relaxes the handler to continue to allow FORGE plugin messages through when the handshake is complete/done, allowing this register message to get through to the client correctly.

This fixes #155, see SpongePowered/SpongeForge#1507