### PR TITLE
Fix #178 Error decoding packet unknown with contents

### DIFF
--- a/BungeeCord-Patches/0003-Add-Waterfall-configuration-files.patch
+++ b/BungeeCord-Patches/0003-Add-Waterfall-configuration-files.patch
@@ -1,11 +1,11 @@
-From 1893ed633fc97a855d0e657baa09feec9f007d11 Mon Sep 17 00:00:00 2001
+From db1bf650eabb7d9056ed89677c737ef455f6a4d1 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 25 Oct 2016 11:58:37 -0400
 Subject: [PATCH] Add Waterfall configuration files
 
 
 diff --git a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
-index edd82c1e..b30541be 100644
+index edd82c1..b30541b 100644
 --- a/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
 +++ b/api/src/main/java/net/md_5/bungee/api/ProxyConfig.java
 @@ -79,4 +79,9 @@ public interface ProxyConfig
@@ -20,7 +20,7 @@ index edd82c1e..b30541be 100644
  }
 diff --git a/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java b/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java
 new file mode 100644
-index 00000000..f9e277dc
+index 0000000..f9e277d
 --- /dev/null
 +++ b/proxy/src/main/java/io/github/waterfallmc/waterfall/conf/WaterfallConfiguration.java
 @@ -0,0 +1,18 @@
@@ -43,7 +43,7 @@ index 00000000..f9e277dc
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 510841c7..78808fb9 100644
+index 510841c..78808fb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -11,6 +11,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -64,7 +64,7 @@ index 510841c7..78808fb9 100644
       * Localization bundle.
       */
 diff --git a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
-index 907246a9..4a55c0e2 100644
+index 907246a..4a55c0e 100644
 --- a/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
 +++ b/proxy/src/main/java/net/md_5/bungee/conf/Configuration.java
 @@ -24,7 +24,7 @@ import net.md_5.bungee.util.CaseInsensitiveSet;
@@ -77,7 +77,7 @@ index 907246a9..4a55c0e2 100644
  
      /**
 diff --git a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
-index 95590b6d..1019c307 100644
+index 95590b6..1019c30 100644
 --- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
 +++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
 @@ -43,10 +43,15 @@ public class YamlConfig implements ConfigurationAdapter
@@ -98,18 +98,18 @@ index 95590b6d..1019c307 100644
          DumperOptions options = new DumperOptions();
          options.setDefaultFlowStyle( DumperOptions.FlowStyle.BLOCK );
          yaml = new Yaml( options );
-@@ -54,6 +59,11 @@ public class YamlConfig implements ConfigurationAdapter
- 
+@@ -55,6 +60,11 @@ public class YamlConfig implements ConfigurationAdapter
      @Override
      public void load()
-+    {
+     {
 +        load(true);
 +    }
 +
 +    public void load(boolean doPermissions)
-     {
++    {
          try
          {
+             file.createNewFile();
 @@ -82,6 +92,7 @@ public class YamlConfig implements ConfigurationAdapter
              throw new RuntimeException( "Could not load configuration!", ex );
          }
@@ -119,5 +119,5 @@ index 95590b6d..1019c307 100644
          if ( permissions.isEmpty() )
          {
 -- 
-2.14.1
+2.8.1.windows.1
 

--- a/BungeeCord-Patches/0017-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0017-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From fbb85275392056b77e760a8e0936c02d0252a620 Mon Sep 17 00:00:00 2001
+From 5e9ff5352f8a2354de70bacf2ff2fb781d1e4e30 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -9,7 +9,7 @@ Vanilla servers still error on negative/invalid packets.
 Original issue: https://github.com/WaterfallMC/Waterfall-Old/issues/11
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index e7cb3803..447eaae7 100644
+index e7cb380..447eaae 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 @@ -16,6 +16,14 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
@@ -37,7 +37,7 @@ index e7cb3803..447eaae7 100644
              {
                  packet.read( in, prot.getDirection(), protocolVersion );
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-index f06aa95a..8e142323 100644
+index f06aa95..8e14232 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 @@ -355,14 +355,23 @@ public enum Protocol
@@ -49,12 +49,12 @@ index f06aa95a..8e142323 100644
 +        }
 +
          public final DefinedPacket createPacket(int id, int version)
-+        {
+         {
 +            return createPacket(id, version, true);
 +        }
 +
 +        public final DefinedPacket createPacket(int id, int version, boolean supportsForge)
-         {
++        {
              ProtocolData protocolData = getProtocolData( version );
              if (protocolData == null)
              {
@@ -66,7 +66,7 @@ index f06aa95a..8e142323 100644
                  throw new BadPacketException( "Packet with id " + id + " outside of range " );
              }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 61c53b30..b29ee7c5 100644
+index 61c53b3..b29ee7c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -29,7 +29,9 @@ import net.md_5.bungee.forge.ForgeUtils;
@@ -93,7 +93,7 @@ index 61c53b30..b29ee7c5 100644
  
          ch.write( BungeeCord.getInstance().registerChannels() );
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 28e79933..ccb6b6ca 100644
+index 28e7993..ccb6b6c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 @@ -70,6 +70,7 @@ public final class UserConnection implements ProxiedPlayer
@@ -105,7 +105,7 @@ index 28e79933..ccb6b6ca 100644
      @Getter
      @NonNull
 diff --git a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-index 847a3eca..27ee21f2 100644
+index 847a3ec..27ee21f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 +++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 @@ -211,6 +211,12 @@ public abstract class EntityMap
@@ -122,5 +122,5 @@ index 847a3eca..27ee21f2 100644
          {
              rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
 -- 
-2.14.1
+2.8.1.windows.1
 

--- a/BungeeCord-Patches/0030-Improve-ServerKickEvent.patch
+++ b/BungeeCord-Patches/0030-Improve-ServerKickEvent.patch
@@ -1,4 +1,4 @@
-From 4f2868a5e5839988b6a17d3204966c9863fb703e Mon Sep 17 00:00:00 2001
+From fa756429b7df31eaf614d6b1559b37b367bdb6ab Mon Sep 17 00:00:00 2001
 From: Nathan Poirier <nathan@poirier.io>
 Date: Tue, 28 Jun 2016 23:00:49 -0500
 Subject: [PATCH] Improve ServerKickEvent
@@ -6,7 +6,7 @@ Subject: [PATCH] Improve ServerKickEvent
 ServerKickEvent traditionally will only fire if the server sends a kick packet. During a server shutdown, or server crash this event would not fire for most players. While ServerDisconnectEvent is fired it does not tell us if it was a kick/shutdown/server crash.  This improvement fires the ServerKickEvent for server caused disconnections, and adds a Cause to the kick event.
 
 diff --git a/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java b/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
-index 0e1ef5c4..ee63732d 100644
+index 0e1ef5c..ee63732 100644
 --- a/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
 +++ b/api/src/main/java/net/md_5/bungee/api/event/ServerKickEvent.java
 @@ -44,6 +44,12 @@ public class ServerKickEvent extends Event implements Cancellable
@@ -44,12 +44,12 @@ index 0e1ef5c4..ee63732d 100644
 +    // Waterfall start
 +    @Deprecated
      public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, BaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state)
-+    {
+     {
 +        this( player, kickedFrom, kickReasonComponent, cancelServer, state, Cause.UNKNOWN );
 +    }
 +
 +    public ServerKickEvent(ProxiedPlayer player, ServerInfo kickedFrom, BaseComponent[] kickReasonComponent, ServerInfo cancelServer, State state, Cause cause)
-     {
++    {
          this.player = player;
          this.kickedFrom = kickedFrom;
          this.kickReasonComponent = kickReasonComponent;
@@ -62,7 +62,7 @@ index 0e1ef5c4..ee63732d 100644
      @Deprecated
      public String getKickReason()
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 79e88cc5..38361c2b 100644
+index 79e88cc..38361c2 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -314,7 +314,7 @@ public class ServerConnector extends PacketHandler
@@ -75,7 +75,7 @@ index 79e88cc5..38361c2b 100644
          {
              // Pre cancel the event if we are going to try another server
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index dcd6924d..de905b83 100644
+index dcd6924..de905b8 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 @@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
@@ -146,5 +146,5 @@ index dcd6924d..de905b83 100644
          {
              con.connectNow( event.getCancelServer() );
 -- 
-2.14.1
+2.8.1.windows.1
 

--- a/BungeeCord-Patches/0042-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/BungeeCord-Patches/0042-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -1,11 +1,11 @@
-From 8d7700a5ef39cf148965e355adafccd27a02900a Mon Sep 17 00:00:00 2001
+From 99a8f432264e2d82f11ba755bd411aa91baedb11 Mon Sep 17 00:00:00 2001
 From: Minecrell <dev@minecrell.net>
 Date: Fri, 22 Sep 2017 13:15:09 +0200
 Subject: [PATCH] Allow plugins to use SLF4J for logging
 
 
 diff --git a/api/pom.xml b/api/pom.xml
-index 2a3c5eae..25d870d1 100644
+index 2a3c5ea..25d870d 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -43,5 +43,12 @@
@@ -22,7 +22,7 @@ index 2a3c5eae..25d870d1 100644
      </dependencies>
  </project>
 diff --git a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
-index e85b4914..2e5ae4fb 100644
+index e85b491..2e5ae4f 100644
 --- a/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
 +++ b/api/src/main/java/net/md_5/bungee/api/plugin/Plugin.java
 @@ -27,6 +27,12 @@ public class Plugin
@@ -39,21 +39,21 @@ index e85b4914..2e5ae4fb 100644
       * Called when the plugin has just been loaded. Most of the proxy will not
       * be initialized, so only use it for registering
 diff --git a/log4j/pom.xml b/log4j/pom.xml
-index 78045e1d..d078cd68 100644
+index 78045e1..d078cd6 100644
 --- a/log4j/pom.xml
 +++ b/log4j/pom.xml
-@@ -34,6 +34,11 @@
-             <artifactId>log4j-jul</artifactId>
+@@ -35,6 +35,11 @@
              <version>2.9.1</version>
          </dependency>
-+        <dependency>
+         <dependency>
 +            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-slf4j-impl</artifactId>
 +            <version>2.9.1</version>
 +        </dependency>
-         <dependency>
++        <dependency>
              <groupId>com.lmax</groupId>
              <artifactId>disruptor</artifactId>
+             <version>3.3.6</version>
 -- 
-2.14.1
+2.8.1.windows.1
 

--- a/BungeeCord-Patches/0045-Fix-178-Error-decoding-packet-unknown-with-contents.patch
+++ b/BungeeCord-Patches/0045-Fix-178-Error-decoding-packet-unknown-with-contents.patch
@@ -1,0 +1,25 @@
+From dfedb33f0509bcc67793c206c61fe82eec019a65 Mon Sep 17 00:00:00 2001
+From: joserobjr <jose.rob.jr@gmail.com>
+Date: Sat, 4 Nov 2017 23:30:31 -0300
+Subject: [PATCH] Fix #178 Error decoding packet unknown with contents
+
+
+diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+index 0b780e2..41fece9 100644
+--- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
++++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
+@@ -36,6 +36,11 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+         Object packetTypeInfo = null;
+         try
+         {
++            if ( in.readerIndex() == in.writerIndex() )
++            {
++                return;
++            }
++
+             int packetId = DefinedPacket.readVarInt( in );
+             packetTypeInfo = packetId;
+ 
+-- 
+2.8.1.windows.1
+


### PR DESCRIPTION
It was happening on my server too and this changed fixed the issue.

This is my first time pushing changes to a patch-based repository, let me know if I did anything wrong generating this patch.

I only added:
```java
            if ( in.readerIndex() == in.writerIndex() )
            {
                return;
            }
```

to the MinecraftDecoder.decode() method as the error happens when the ByteBuf has no byte available to be read.