### PR TITLE
Update Maven Deploy URL

### DIFF
--- a/BungeeCord-Patches/0001-POM-Changes.patch
+++ b/BungeeCord-Patches/0001-POM-Changes.patch
@@ -1,4 +1,4 @@
-From 3a437a7b1b6a3a96ba2245e091e3689041e94f3e Mon Sep 17 00:00:00 2001
+From e9691571a6ae80c2f3faedd8c790d11cb914fd28 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 10:33:31 -0700
 Subject: [PATCH] POM Changes
@@ -494,7 +494,7 @@ index 082f0908..8b045e3b 100644
      <dependencies>
          <dependency>
 diff --git a/pom.xml b/pom.xml
-index 96b36d5f..7cf3b7ff 100644
+index 96b36d5f..c10c6442 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,18 +3,25 @@
@@ -577,13 +577,13 @@ index 96b36d5f..7cf3b7ff 100644
      <distributionManagement>
 +        <repository>
 +            <id>destroystokyo-releases</id>
-+            <url>https://repo.destroystokyo.com/repository/maven-releases/</url>
++            <url>https://destroystokyo.com/repo/repository/maven-releases/</url>
 +        </repository>
          <snapshotRepository>
 -            <id>sonatype-nexus-snapshots</id>
 -            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 +            <id>destroystokyo-snapshots</id>
-+            <url>https://repo.destroystokyo.com/repository/maven-snapshots/</url>
++            <url>https://destroystokyo.com/repo/repository/maven-snapshots/</url>
          </snapshotRepository>
      </distributionManagement>
  
@@ -828,5 +828,5 @@ index 9ecb2612..4b3613fa 100644
              <scope>compile</scope>
          </dependency>
 -- 
-2.16.1
+2.17.0.windows.1
 


### PR DESCRIPTION
We recently moved some things around and as a result several URLs
changed.

Redirects are in place and most users will not need to make any changes.
We have already tested and confirmed that maven access works just fine
via the redirects.

However, maven will not allow you to deploy through the redirect so
projects using old deploy URLs will need to be updated.