### PR TITLE
Set up Log4j 2 async loggers using system property

### DIFF
--- a/BungeeCord-Patches/0040-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
+++ b/BungeeCord-Patches/0040-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
@@ -1,4 +1,4 @@
-From 5b28001ff643ac29ecd7f73d19689019a326c81d Mon Sep 17 00:00:00 2001
+From 5872d7cacee483a8c84ffc319c1ffcf7d5bfc037 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 22 Sep 2017 12:46:47 +0200
 Subject: [PATCH] Use Log4j2 for logging and TerminalConsoleAppender for
@@ -204,9 +204,16 @@ index 00000000..a0f7ed01
 +    }
 +
 +}
+diff --git a/log4j/src/main/resources/log4j2.component.properties b/log4j/src/main/resources/log4j2.component.properties
+new file mode 100644
+index 00000000..6ed08f31
+--- /dev/null
++++ b/log4j/src/main/resources/log4j2.component.properties
+@@ -0,0 +1 @@
++log4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
 diff --git a/log4j/src/main/resources/log4j2.xml b/log4j/src/main/resources/log4j2.xml
 new file mode 100644
-index 00000000..d4a81199
+index 00000000..93ce3b14
 --- /dev/null
 +++ b/log4j/src/main/resources/log4j2.xml
 @@ -0,0 +1,22 @@
@@ -226,10 +233,10 @@ index 00000000..d4a81199
 +    </Appenders>
 +
 +    <Loggers>
-+        <AsyncRoot level="info">
++        <Root level="info">
 +            <AppenderRef ref="TerminalConsole" />
 +            <AppenderRef ref="File" />
-+        </AsyncRoot>
++        </Root>
 +    </Loggers>
 +</Configuration>
 diff --git a/pom.xml b/pom.xml

--- a/BungeeCord-Patches/0043-Add-Log4j-configuration-that-replicates-the-old-Bung.patch
+++ b/BungeeCord-Patches/0043-Add-Log4j-configuration-that-replicates-the-old-Bung.patch
@@ -1,4 +1,4 @@
-From 11629f33a3756606d47546784605aa3a7ae7fb41 Mon Sep 17 00:00:00 2001
+From ca65f501ae9962731c785cba7d7b3b1357f8df4e Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Sun, 24 Sep 2017 12:06:49 +0200
 Subject: [PATCH] Add Log4j configuration that replicates the old BungeeCord
@@ -8,7 +8,7 @@ Can be enabled using -Dlog4j.configurationFile=log4j2-bungee.xml.
 
 diff --git a/log4j/src/main/resources/log4j2-bungee.xml b/log4j/src/main/resources/log4j2-bungee.xml
 new file mode 100644
-index 00000000..bf132953
+index 00000000..6e9c09c5
 --- /dev/null
 +++ b/log4j/src/main/resources/log4j2-bungee.xml
 @@ -0,0 +1,34 @@
@@ -40,10 +40,10 @@ index 00000000..bf132953
 +    </Appenders>
 +
 +    <Loggers>
-+        <AsyncRoot level="info">
++        <Root level="info">
 +            <AppenderRef ref="TerminalConsole" />
 +            <AppenderRef ref="File" />
-+        </AsyncRoot>
++        </Root>
 +    </Loggers>
 +</Configuration>
 -- 


### PR DESCRIPTION
From the [Log4j 2 documentation](https://logging.apache.org/log4j/2.x/manual/async.html):

> When `AsyncLoggerContextSelector` is used to make all loggers asynchronous, make sure to use normal `<root>` and `<logger>` elements in the configuration. The `AsyncLoggerContextSelector` will ensure that all loggers are asynchronous, using a mechanism that is different from what happens when you configure `<asyncRoot>` or `<asyncLogger>`. **The latter elements are intended for mixing async with sync loggers.**

Since we are not using mixed sync/async loggers, we should use the system property to enable the async loggers.