### PR TITLE
Improved TabCompleteResponseEvent

### DIFF
--- a/BungeeCord-Patches/0048-Improved-TabCompleteResponseEvent.patch
+++ b/BungeeCord-Patches/0048-Improved-TabCompleteResponseEvent.patch
@@ -1,0 +1,413 @@
+From a688607cad823893ee8498c3a96408702efdee2a Mon Sep 17 00:00:00 2001
+From: JOO200 <git@johanneszangl.de>
+Date: Fri, 1 Feb 2019 00:41:55 +0100
+Subject: [PATCH] Improved TabCompleteResponseEvent: * Give access to
+ Brigadier's Suggestions object. * Access to the list of suggestions through a
+ self written list class
+
+
+diff --git a/api/src/main/java/io/github/waterfallmc/waterfall/utils/SuggestionList.java b/api/src/main/java/io/github/waterfallmc/waterfall/utils/SuggestionList.java
+new file mode 100644
+index 00000000..0cc9c8c0
+--- /dev/null
++++ b/api/src/main/java/io/github/waterfallmc/waterfall/utils/SuggestionList.java
+@@ -0,0 +1,304 @@
++package io.github.waterfallmc.waterfall.utils;
++
++import com.mojang.brigadier.suggestion.Suggestion;
++import com.mojang.brigadier.suggestion.Suggestions;
++
++import java.util.*;
++import java.util.function.Consumer;
++import java.util.function.Predicate;
++import java.util.stream.Stream;
++
++/**
++ * A list that redirects to brigadier suggestions.
++ */
++public class SuggestionList implements List<String> {
++    private Suggestions suggestions;
++    public SuggestionList(Suggestions suggestions) {
++        Objects.requireNonNull(suggestions);
++        this.suggestions = suggestions;
++    }
++
++    private Suggestions getSuggestions() {
++        return this.suggestions;
++    }
++
++    @Override
++    public int size() {
++        return suggestions.getList().size();
++    }
++
++    @Override
++    public boolean isEmpty() {
++        return suggestions.getList().isEmpty();
++    }
++
++    @Override
++    public boolean contains(Object o) {
++        return indexOf(o) >= 0;
++    }
++
++    @Override
++    public Iterator<String> iterator() {
++        return new SuggestionListIterator(0);
++    }
++
++    @Override
++    public Object[] toArray() {
++        String[] obj = new String[size()];
++        for(int i = 0; i < size(); i++) {
++            obj[i] = suggestions.getList().get(i).getText();
++        }
++        return obj;
++    }
++
++    @Override
++    @SuppressWarnings("unchecked")
++    public <T> T[] toArray(T[] a) {
++        return (T[])toArray();
++    }
++
++    @Override
++    public boolean add(String s) {
++        Objects.requireNonNull(s);
++        return suggestions.getList().add(new Suggestion(suggestions.getRange(), s));
++    }
++
++    @Override
++    public boolean remove(Object o) {
++        if(o instanceof Suggestion) {
++            return suggestions.getList().remove(o);
++        } else if(o instanceof String) {
++            for (Suggestion suggestion : suggestions.getList()) {
++                if(suggestion.getText().equals(o)) {
++                    return suggestions.getList().remove(suggestion);
++                }
++            }
++        }
++        return false;
++    }
++
++    @Override
++    public boolean containsAll(Collection<?> coll) {
++        Objects.requireNonNull(coll);
++        for(Object c : coll) {
++            if(!contains(c)) return false;
++        }
++        return true;
++    }
++
++    @Override
++    public boolean addAll(Collection<? extends String> c) {
++        Objects.requireNonNull(c);
++        for(String string : c) {
++            if(!add(string)) return false;
++        }
++        return true;
++    }
++
++    @Override
++    public boolean addAll(int index, Collection<? extends String> c) {
++        Objects.requireNonNull(c);
++        return addAll(c);
++    }
++
++    @Override
++    public boolean removeAll(Collection<?> c) {
++        Objects.requireNonNull(c);
++        for(Object o : c) {
++            if(!remove(o)) return false;
++        }
++        return true;
++    }
++
++    @Override
++    public boolean retainAll(Collection<?> c) {
++        Objects.requireNonNull(c);
++        for(Object o : c) {
++            if(!contains(o)) remove(o);
++        }
++        return true;
++    }
++
++    @Override
++    public boolean removeIf(Predicate<? super String> filter) {
++        Objects.requireNonNull(filter);
++        return suggestions.getList().removeIf(suggestion -> filter.test(suggestion.getText()));
++    }
++
++    @Override
++    public void sort(Comparator<? super String> c) {
++        // Do nothing. There is no need to sort the Suggestion list. The client will sort the list for his own.
++    }
++
++    @Override
++    public void clear() {
++        suggestions.getList().clear();
++    }
++
++    @Override
++    public boolean equals(Object o) {
++        if(o instanceof SuggestionList) {
++            return suggestions.equals(((SuggestionList) o).getSuggestions());
++        } else if(o instanceof Suggestions) {
++            return suggestions.equals(o);
++        }
++        return false;
++    }
++
++    @Override
++    public String get(int index) {
++        return suggestions.getList().get(index).getText();
++    }
++
++    @Override
++    public String set(int index, String element) {
++        Objects.requireNonNull(element);
++        Suggestion suggestion = suggestions.getList().get(index);
++        suggestions.getList().set(index, new Suggestion(suggestion.getRange(), element));
++        return element;
++    }
++
++    @Override
++    public void add(int index, String element) {
++        add(element);
++    }
++
++    @Override
++    public String remove(int index) {
++        return suggestions.getList().remove(index).getText();
++    }
++
++    @Override
++    public int indexOf(Object o) {
++        if (o == null) {
++            return -1;
++        }
++        for(int i = 0; i < size(); i++) {
++            if (o.equals(suggestions.getList().get(i)))
++                return i;
++        }
++        return -1;
++    }
++
++    @Override
++    public int lastIndexOf(Object o) {
++        if (o == null)
++            return -1;
++        for(int i = size()-1; i >= 0; i--) {
++            if (o.equals(suggestions.getList().get(i)))
++                return i;
++        }
++        return -1;
++    }
++
++    @Override
++    public ListIterator<String> listIterator() {
++        return listIterator(0);
++    }
++
++    @Override
++    public ListIterator<String> listIterator(int index) {
++        return new SuggestionListIterator(index);
++    }
++
++    @Override
++    public List<String> subList(int fromIndex, int toIndex) {
++        if (fromIndex < 0)
++            throw new IndexOutOfBoundsException("fromIndex = " + fromIndex);
++        if (toIndex > size())
++            throw new IndexOutOfBoundsException("toIndex = " + toIndex);
++        if (fromIndex > toIndex)
++            throw new IllegalArgumentException("fromIndex(" + fromIndex +
++                    ") > toIndex(" + toIndex + ")");
++        List<String> list = new ArrayList<>(size());
++        for(Suggestion suggestion : suggestions.getList())
++            list.add(suggestion.getText());
++        return list;
++    }
++
++    @Override
++    public void forEach(Consumer<? super String> action) {
++        Objects.requireNonNull(action);
++        for (Suggestion suggestion : suggestions.getList()) {
++            action.accept(suggestion.getText());
++        }
++    }
++
++    @Override
++    public Spliterator<String> spliterator() {
++        ArrayList<String> list = new ArrayList<>();
++        for (Suggestion suggestion : suggestions.getList())
++            list.add(suggestion.getText());
++        return list.spliterator();
++    }
++
++    @Override
++    public Stream<String> stream() {
++        return suggestions.getList().stream().map(Suggestion::getText);
++    }
++
++    @Override
++    public Stream<String> parallelStream() {
++        return suggestions.getList().parallelStream().map(Suggestion::getText);
++    }
++
++    final class SuggestionListIterator implements ListIterator<String> {
++        int currIndex;
++
++        SuggestionListIterator(int index) {
++            this.currIndex = index;
++        }
++
++        @Override
++        public boolean hasNext() {
++            return size() > currIndex;
++        }
++
++        @Override
++        public String next() {
++            currIndex++;
++            return get(currIndex);
++        }
++
++        @Override
++        public boolean hasPrevious() {
++            return currIndex < 0;
++        }
++
++        @Override
++        public String previous() {
++            currIndex--;
++            return get(currIndex);
++        }
++
++        @Override
++        public int nextIndex() {
++            return currIndex + 1;
++        }
++
++        @Override
++        public int previousIndex() {
++            return currIndex - 1;
++        }
++
++        @Override
++        public void remove() {
++            suggestions.getList().remove(currIndex);
++        }
++
++        @Override
++        public void forEachRemaining(Consumer<? super String> action) {
++
++        }
++
++        @Override
++        public void set(String s) {
++            SuggestionList.this.set(currIndex, s);
++        }
++
++        @Override
++        public void add(String s) {
++            SuggestionList.this.add(currIndex, s);
++        }
++    }
++}
+diff --git a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
+index ea0ce89c..56a602d0 100644
+--- a/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
++++ b/api/src/main/java/net/md_5/bungee/api/event/TabCompleteResponseEvent.java
+@@ -1,5 +1,6 @@
+ package net.md_5.bungee.api.event;
+ 
++import com.mojang.brigadier.suggestion.Suggestions;
+ import lombok.Data;
+ import lombok.EqualsAndHashCode;
+ import lombok.ToString;
+@@ -30,9 +31,18 @@ public class TabCompleteResponseEvent extends TargetedEvent implements Cancellab
+      */
+     private final List<String> suggestions;
+ 
+-    public TabCompleteResponseEvent(Connection sender, Connection receiver, List<String> suggestions)
++    // Waterfall start
++    /**
++     * The reference for tab completions for minecraft versions >= 1.13
++     */
++    private final Suggestions brigadierSuggestions;
++
++
++    public TabCompleteResponseEvent(Connection sender, Connection receiver, List<String> suggestions, Suggestions brigadierSuggestions)
+     {
+         super( sender, receiver );
+         this.suggestions = suggestions;
++        this.brigadierSuggestions = brigadierSuggestions;
++        // Waterfall end
+     }
+ }
+diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+index 8469e665..515b52c7 100644
+--- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
++++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
+@@ -15,6 +15,8 @@ import com.mojang.brigadier.suggestion.Suggestions;
+ import com.mojang.brigadier.tree.LiteralCommandNode;
+ import java.io.DataInput;
+ import java.util.Objects; // Waterfall
++
++import io.github.waterfallmc.waterfall.utils.SuggestionList;
+ import io.netty.buffer.ByteBuf;
+ import io.netty.buffer.ByteBufAllocator;
+ import io.netty.buffer.Unpooled;
+@@ -529,41 +531,16 @@ public class DownstreamBridge extends PacketHandler
+         List<String> commands = tabCompleteResponse.getCommands();
+         if ( commands == null )
+         {
+-            commands = Lists.transform( tabCompleteResponse.getSuggestions().getList(), new Function<Suggestion, String>()
+-            {
+-                @Override
+-                public String apply(Suggestion input)
+-                {
+-                    return input.getText();
+-                }
+-            } );
++            // Waterfall start - replace
++            commands = new SuggestionList(tabCompleteResponse.getSuggestions());
+         }
+ 
+-        TabCompleteResponseEvent tabCompleteResponseEvent = new TabCompleteResponseEvent( server, con, new ArrayList<>( commands ) );
++        TabCompleteResponseEvent tabCompleteResponseEvent =
++                new TabCompleteResponseEvent( server, con, commands, tabCompleteResponse.getSuggestions());
+         if ( !bungee.getPluginManager().callEvent( tabCompleteResponseEvent ).isCancelled() )
+         {
+-            // Take action only if modified
+-            if ( !commands.equals( tabCompleteResponseEvent.getSuggestions() ) )
+-            {
+-                if ( tabCompleteResponse.getCommands() != null )
+-                {
+-                    // Classic style
+-                    tabCompleteResponse.setCommands( tabCompleteResponseEvent.getSuggestions() );
+-                } else
+-                {
+-                    // Brigadier style
+-                    final StringRange range = tabCompleteResponse.getSuggestions().getRange();
+-                    tabCompleteResponse.setSuggestions( new Suggestions( range, Lists.transform( tabCompleteResponseEvent.getSuggestions(), new Function<String, Suggestion>()
+-                    {
+-                        @Override
+-                        public Suggestion apply(String input)
+-                        {
+-                            return new Suggestion( range, input );
+-                        }
+-                    } ) ) );
+-                }
+-            }
+-
++            // All modifications from the list are done in the Suggestions object.
++            // Waterfall end
+             con.unsafe().sendPacket( tabCompleteResponse );
+         }
+ 
+-- 
+2.18.0.windows.1
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ While we will fix minor formatting issues, you should stick to the guide below w
 ## Formatting
 All modifications to non-Waterfall files should be marked
 - Multi line changes start with `// Waterfall start` and end with `// Waterfall end`
-- You can put a messages with a change if it isn't obvious, like this: `// Waterfall start - reason
+- You can put a messages with a change if it isn't obvious, like this: `// Waterfall start - reason`
   - Should generally be about the reason the change was made, what it was before, or what the change is
   - Multi-line messages should start with `// Waterfall start` and use `/* Multi line message here */` for the message itself
 - Single line changes should have `// Waterfall` or `// Waterfall - reason`


### PR DESCRIPTION
- Give access to Brigadier's Suggestions object.
- Access to the list of suggestions through a self written list class

### Reasons for the change:
The TabCompleteResponseEvent from BungeeCord has a new behavior with Minecraft's Brigadier:
1. Load all TabCompletions from spigot in the Suggestions object.
2. Move the text from all TabCompletions in a ArrayList.
3. Call the TabCompleteResponseEvent
4. If the event changed single TabCompletions: Create a new Suggestions object from the ArrayList. Drop all existing Tooltips.

There will probably be no plugin that offers tooltips. But it will only be a matter of time before problems arise with this handling.

I tested it with Spigot 1.13.2 and Spigot 1.12.2

### Questions:
- Should I add some test cases?
- This might be an interesting idea for TabCompleteEvent.
- Add a config variable to enable this handling?