### PR TITLE
Removed duplicated javadoc param

### DIFF
--- a/BungeeCord-Patches/0050-Fix-upstream-javadocs.patch
+++ b/BungeeCord-Patches/0050-Fix-upstream-javadocs.patch
@@ -1,4 +1,4 @@
-From 8452d6a2710d398005009f8dbffd8fe0935145f4 Mon Sep 17 00:00:00 2001
+From 1f214e0f51add45580c27f75825d1516ff438827 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sat, 30 Mar 2019 15:11:11 +0000
 Subject: [PATCH] Fix upstream javadocs
@@ -103,18 +103,6 @@ index f3bced0a..4a198ee9 100644
       */
      Favicon getFaviconObject();
  
-diff --git a/api/src/main/java/net/md_5/bungee/api/scheduler/TaskScheduler.java b/api/src/main/java/net/md_5/bungee/api/scheduler/TaskScheduler.java
-index 32732703..46d70184 100644
---- a/api/src/main/java/net/md_5/bungee/api/scheduler/TaskScheduler.java
-+++ b/api/src/main/java/net/md_5/bungee/api/scheduler/TaskScheduler.java
-@@ -85,6 +85,7 @@ public interface TaskScheduler
- 
-         /**
-          * An executor service which underlies this scheduler.
-+         * @param plugin The plugin of which to fetch an executor service for
-          *
-          * @param plugin owning plugin
-          * @return the underlying executor service or compatible wrapper
 -- 
-2.25.0
+2.23.0.windows.1
 


### PR DESCRIPTION
This causes the build to fail when using upstream's new profile "dest" with the following command:

`mvn -P dist package`

```
[WARNING] Javadoc Warnings
[WARNING] C:\Users\artut\Documents\Projects\Minecraft\Waterfall\Waterfall-Proxy\api\src\main\java\net\md_5\bungee\api\scheduler\TaskScheduler.java:93: warning - Parameter "plugin" is documented more than once.
```