### PR TITLE
Do not throw IllegalArgumentException when empty chat has sent

### DIFF
--- a/BungeeCord-Patches/0024-Validate-that-chat-messages-are-non-blank.patch
+++ b/BungeeCord-Patches/0024-Validate-that-chat-messages-are-non-blank.patch
@@ -48,7 +48,7 @@ index 4bb61f63..9287d168 100644
      {
          int maxLength = ( con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_11 ) ? 256 : 100;
          Preconditions.checkArgument( chat.getMessage().length() <= maxLength, "Chat message too long" ); // Mojang limit, check on updates
-+        Preconditions.checkArgument(!StringUtil.isBlank(chat.getMessage()), "Chat message is empty");
++        if (StringUtil.isBlank(chat.getMessage())) return;
  
          ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );
          if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )


### PR DESCRIPTION
Replaces a Preconditions API call with the simple if/return statement.
This Pull Request fixes Issue #413 

## Behavior Changes:

### Before
Throws IllegalArgumentException if received an empty chat.

### After
The empty chat is **ignored quietly**.
