### PR TITLE
Bump Netty to 4.1.49.Final

### DIFF
--- a/BungeeCord-Patches/0055-Bump-Netty-to-4.1.49.Final.patch
+++ b/BungeeCord-Patches/0055-Bump-Netty-to-4.1.49.Final.patch
@@ -1,0 +1,24 @@
+From 3839feee87336320de5d39dc5a70fd82e90d63ef Mon Sep 17 00:00:00 2001
+From: Andrew Steinborn <git@steinborn.me>
+Date: Wed, 22 Apr 2020 10:22:09 -0400
+Subject: [PATCH] Bump Netty to 4.1.49.Final
+
+Fixes https://github.com/netty/netty/issues/10165, also known as
+"bungeecrasher" amongst other names.
+
+diff --git a/pom.xml b/pom.xml
+index f6ff86a2..c9531d39 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -91,7 +91,7 @@
+ 
+     <properties>
+         <build.number>unknown</build.number>
+-        <netty.version>4.1.48.Final</netty.version>
++        <netty.version>4.1.49.Final</netty.version>
+         <maven.compiler.source>1.8</maven.compiler.source>
+         <maven.compiler.target>1.8</maven.compiler.target>
+         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+-- 
+2.26.2
+


### PR DESCRIPTION
This release includes the fix for netty/netty#10165, also known as "bungeecrasher" or "bungeespammer" amongst other names.