### PR TITLE
Add a command to view all plugins on the proxy

### DIFF
--- a/BungeeCord-Patches/0063-Add-command-to-view-all-proxy-plugins.patch
+++ b/BungeeCord-Patches/0063-Add-command-to-view-all-proxy-plugins.patch
@@ -1,82 +1,69 @@
-From ff5ca7dc3ef58315821a5d86a527f0a0af82e693 Mon Sep 17 00:00:00 2001
+From becd7e8441c4b43f1b80f18d4ed721321b626b1b Mon Sep 17 00:00:00 2001
 From: MrFishCakes <fishcake007@outlook.com>
-Date: Thu, 20 May 2021 16:49:45 +0100
+Date: Thu, 20 May 2021 17:43:55 +0100
 Subject: [PATCH] Add command to view all proxy plugins
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index c09f5b4c..00906d3f 100644
+index 00906d3f..5e9fde6d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -75,12 +75,7 @@ import net.md_5.bungee.chat.ScoreComponentSerializer;
+@@ -75,7 +75,13 @@ import net.md_5.bungee.chat.ScoreComponentSerializer;
  import net.md_5.bungee.chat.SelectorComponentSerializer;
  import net.md_5.bungee.chat.TextComponentSerializer;
  import net.md_5.bungee.chat.TranslatableComponentSerializer;
--import net.md_5.bungee.command.CommandBungee;
--import net.md_5.bungee.command.CommandEnd;
--import net.md_5.bungee.command.CommandIP;
--import net.md_5.bungee.command.CommandPerms;
--import net.md_5.bungee.command.CommandReload;
--import net.md_5.bungee.command.ConsoleCommandSender;
-+import net.md_5.bungee.command.*;
+-import net.md_5.bungee.command.*;
++import net.md_5.bungee.command.CommandBungee;
++import net.md_5.bungee.command.CommandEnd;
++import net.md_5.bungee.command.CommandIP;
++import net.md_5.bungee.command.CommandPerms;
++import net.md_5.bungee.command.CommandPlugins;
++import net.md_5.bungee.command.CommandReload;
++import net.md_5.bungee.command.ConsoleCommandSender;
  import net.md_5.bungee.compress.CompressFactory;
  import net.md_5.bungee.conf.Configuration;
  import net.md_5.bungee.conf.YamlConfig;
-@@ -230,6 +225,7 @@ public class BungeeCord extends ProxyServer
-         getPluginManager().registerCommand( null, new CommandIP() );
-         getPluginManager().registerCommand( null, new CommandBungee() );
-         getPluginManager().registerCommand( null, new CommandPerms() );
-+        getPluginManager().registerCommand( null, new CommandPlugins() ); // Waterfall - Register /gplugins command
- 
-         if ( !Boolean.getBoolean( "net.md_5.bungee.native.disable" ) )
-         {
 diff --git a/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java b/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java
-new file mode 100644
-index 00000000..0a8cd585
---- /dev/null
+index 0a8cd585..442c0f3f 100644
+--- a/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java
 +++ b/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java
-@@ -0,0 +1,41 @@
-+package net.md_5.bungee.command;
-+
-+import net.md_5.bungee.BungeeCord;
-+import net.md_5.bungee.api.ChatColor;
-+import net.md_5.bungee.api.CommandSender;
-+import net.md_5.bungee.api.plugin.Command;
-+import net.md_5.bungee.api.plugin.Plugin;
-+
-+import java.util.Collection;
-+
-+// Waterfall - Add command to view all plugins on the proxy
-+public class CommandPlugins extends Command {
-+
-+    public CommandPlugins() {
-+        super("gplugins", "bungeecord.command.plugins", "gpl");
-+    }
-+
-+    @Override
-+    public void execute(CommandSender sender, String[] args) {
-+        sender.sendMessage(getPluginList());
-+    }
-+
-+    private String getPluginList() {
-+        final Collection<Plugin> plugins = BungeeCord.getInstance().getPluginManager().getPlugins();
-+        final StringBuilder builder = new StringBuilder("Proxy Plugins (" + plugins.size() + "): ");
-+
-+        boolean firstIteration = true;
-+        for (Plugin plugin : plugins) {
-+            if (!firstIteration) {
-+                builder.append(ChatColor.WHITE).append(", ");
-+            } else {
-+                firstIteration = false;
-+            }
-+
-+            builder.append(ChatColor.GREEN).append(plugin.getDescription().getName());
-+        }
-+
-+        return builder.toString();
-+    }
-+
-+}
+@@ -3,6 +3,7 @@ package net.md_5.bungee.command;
+ import net.md_5.bungee.BungeeCord;
+ import net.md_5.bungee.api.ChatColor;
+ import net.md_5.bungee.api.CommandSender;
++import net.md_5.bungee.api.chat.TextComponent;
+ import net.md_5.bungee.api.plugin.Command;
+ import net.md_5.bungee.api.plugin.Plugin;
+ 
+@@ -20,22 +21,23 @@ public class CommandPlugins extends Command {
+         sender.sendMessage(getPluginList());
+     }
+ 
+-    private String getPluginList() {
++    // TODO Implement as Adventure components when added
++    private TextComponent getPluginList() {
+         final Collection<Plugin> plugins = BungeeCord.getInstance().getPluginManager().getPlugins();
+-        final StringBuilder builder = new StringBuilder("Proxy Plugins (" + plugins.size() + "): ");
++        final TextComponent component = new TextComponent("Plugins (" + plugins.size() + "): ");
+ 
+         boolean firstIteration = true;
+         for (Plugin plugin : plugins) {
+             if (!firstIteration) {
+-                builder.append(ChatColor.WHITE).append(", ");
++                component.addExtra(ChatColor.WHITE + ", ");
+             } else {
+                 firstIteration = false;
+             }
+ 
+-            builder.append(ChatColor.GREEN).append(plugin.getDescription().getName());
++            component.addExtra(ChatColor.GREEN + plugin.getDescription().getName());
+         }
+ 
+-        return builder.toString();
++        return component;
+     }
+ 
+ }
 -- 
 2.26.2.windows.1
 

--- a/BungeeCord-Patches/0063-Add-command-to-view-all-proxy-plugins.patch
+++ b/BungeeCord-Patches/0063-Add-command-to-view-all-proxy-plugins.patch
@@ -1,0 +1,79 @@
+From 333ca65e32247d5d2941a638b16d829a8409d80c Mon Sep 17 00:00:00 2001
+From: MrFishCakes <fishcake007@outlook.com>
+Date: Thu, 20 May 2021 15:23:21 +0100
+Subject: [PATCH] Add command to view all proxy plugins
+
+
+diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+index c09f5b4c..82ba69f9 100644
+--- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
++++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
+@@ -75,12 +75,7 @@ import net.md_5.bungee.chat.ScoreComponentSerializer;
+ import net.md_5.bungee.chat.SelectorComponentSerializer;
+ import net.md_5.bungee.chat.TextComponentSerializer;
+ import net.md_5.bungee.chat.TranslatableComponentSerializer;
+-import net.md_5.bungee.command.CommandBungee;
+-import net.md_5.bungee.command.CommandEnd;
+-import net.md_5.bungee.command.CommandIP;
+-import net.md_5.bungee.command.CommandPerms;
+-import net.md_5.bungee.command.CommandReload;
+-import net.md_5.bungee.command.ConsoleCommandSender;
++import net.md_5.bungee.command.*;
+ import net.md_5.bungee.compress.CompressFactory;
+ import net.md_5.bungee.conf.Configuration;
+ import net.md_5.bungee.conf.YamlConfig;
+@@ -230,6 +225,7 @@ public class BungeeCord extends ProxyServer
+         getPluginManager().registerCommand( null, new CommandIP() );
+         getPluginManager().registerCommand( null, new CommandBungee() );
+         getPluginManager().registerCommand( null, new CommandPerms() );
++        getPluginManager().registerCommand( null, new CommandPlugins() ); // Waterfall - register /gplugins command
+ 
+         if ( !Boolean.getBoolean( "net.md_5.bungee.native.disable" ) )
+         {
+diff --git a/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java b/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java
+new file mode 100644
+index 00000000..dd7f4480
+--- /dev/null
++++ b/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java
+@@ -0,0 +1,37 @@
++package net.md_5.bungee.command;
++
++import net.md_5.bungee.BungeeCord;
++import net.md_5.bungee.api.ChatColor;
++import net.md_5.bungee.api.CommandSender;
++import net.md_5.bungee.api.plugin.Command;
++import net.md_5.bungee.api.plugin.Plugin;
++
++import java.util.Collection;
++
++public class CommandPlugins extends Command {
++
++    public CommandPlugins() {
++        super("gplugins", "bungeecord.command.plugins", "gpl");
++    }
++
++    @Override
++    public void execute(CommandSender sender, String[] args) {
++        sender.sendMessage("Proxy Plugins " + getPluginList());
++    }
++
++    // Code from Bukkit for simplicity
++    private String getPluginList() {
++        final Collection<Plugin> plugins = BungeeCord.getInstance().getPluginManager().getPlugins();
++        final StringBuilder builder = new StringBuilder();
++
++        for (Plugin plugin : plugins) {
++            if (builder.length() > 0) {
++                builder.append(ChatColor.WHITE).append(", ");
++            }
++
++            builder.append(ChatColor.GREEN).append(plugin.getDescription().getName());
++        }
++
++        return "(" + plugins.size() + ") " + builder.toString();
++    }
++
++}
+-- 
+2.26.2.windows.1
+

--- a/BungeeCord-Patches/0063-Add-command-to-view-all-proxy-plugins.patch
+++ b/BungeeCord-Patches/0063-Add-command-to-view-all-proxy-plugins.patch
@@ -1,11 +1,11 @@
-From 333ca65e32247d5d2941a638b16d829a8409d80c Mon Sep 17 00:00:00 2001
+From ff5ca7dc3ef58315821a5d86a527f0a0af82e693 Mon Sep 17 00:00:00 2001
 From: MrFishCakes <fishcake007@outlook.com>
-Date: Thu, 20 May 2021 15:23:21 +0100
+Date: Thu, 20 May 2021 16:49:45 +0100
 Subject: [PATCH] Add command to view all proxy plugins
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index c09f5b4c..82ba69f9 100644
+index c09f5b4c..00906d3f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 @@ -75,12 +75,7 @@ import net.md_5.bungee.chat.ScoreComponentSerializer;
@@ -26,16 +26,16 @@ index c09f5b4c..82ba69f9 100644
          getPluginManager().registerCommand( null, new CommandIP() );
          getPluginManager().registerCommand( null, new CommandBungee() );
          getPluginManager().registerCommand( null, new CommandPerms() );
-+        getPluginManager().registerCommand( null, new CommandPlugins() ); // Waterfall - register /gplugins command
++        getPluginManager().registerCommand( null, new CommandPlugins() ); // Waterfall - Register /gplugins command
  
          if ( !Boolean.getBoolean( "net.md_5.bungee.native.disable" ) )
          {
 diff --git a/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java b/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java
 new file mode 100644
-index 00000000..dd7f4480
+index 00000000..0a8cd585
 --- /dev/null
 +++ b/proxy/src/main/java/net/md_5/bungee/command/CommandPlugins.java
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,41 @@
 +package net.md_5.bungee.command;
 +
 +import net.md_5.bungee.BungeeCord;
@@ -46,6 +46,7 @@ index 00000000..dd7f4480
 +
 +import java.util.Collection;
 +
++// Waterfall - Add command to view all plugins on the proxy
 +public class CommandPlugins extends Command {
 +
 +    public CommandPlugins() {
@@ -54,23 +55,25 @@ index 00000000..dd7f4480
 +
 +    @Override
 +    public void execute(CommandSender sender, String[] args) {
-+        sender.sendMessage("Proxy Plugins " + getPluginList());
++        sender.sendMessage(getPluginList());
 +    }
 +
-+    // Code from Bukkit for simplicity
 +    private String getPluginList() {
 +        final Collection<Plugin> plugins = BungeeCord.getInstance().getPluginManager().getPlugins();
-+        final StringBuilder builder = new StringBuilder();
++        final StringBuilder builder = new StringBuilder("Proxy Plugins (" + plugins.size() + "): ");
 +
++        boolean firstIteration = true;
 +        for (Plugin plugin : plugins) {
-+            if (builder.length() > 0) {
++            if (!firstIteration) {
 +                builder.append(ChatColor.WHITE).append(", ");
++            } else {
++                firstIteration = false;
 +            }
 +
 +            builder.append(ChatColor.GREEN).append(plugin.getDescription().getName());
 +        }
 +
-+        return "(" + plugins.size() + ") " + builder.toString();
++        return builder.toString();
 +    }
 +
 +}


### PR DESCRIPTION
Although not useful for everyone, it can have a purpose. 

The command simply shows what plugins are active on the proxy, in the same way as `/plugins` does on Bukkit. It would be useful for developers that might not be able to view a full console (due to line limits with hosts) to see if their plugin has been loaded/enabled. It can also be used by owners to see if a plugin has loaded or to see what plugins are installed without having to access files directly.