### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0010-Don-t-access-a-ByteBuf-s-underlying-array.patch
+++ b/BungeeCord-Patches/0010-Don-t-access-a-ByteBuf-s-underlying-array.patch
@@ -1,4 +1,4 @@
-From 53eb2f19e3de4b0b3967e8844f0b9d38b48dda04 Mon Sep 17 00:00:00 2001
+From deeb66432761cb3ae27be58738fcb01e5a727f29 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 3 May 2016 20:31:52 -0700
 Subject: [PATCH] Don't access a ByteBuf's underlying array
@@ -43,10 +43,10 @@ index c01cf317..17e12655 100644
       * Allow this packet to be sent as an "extended" packet.
       */
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index fa2ceec5..94b3e7ad 100644
+index a87585fb..795ba6b6 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -239,7 +239,7 @@ public class ServerConnector extends PacketHandler
+@@ -240,7 +240,7 @@ public class ServerConnector extends PacketHandler
              {
                  ByteBuf brand = ByteBufAllocator.DEFAULT.heapBuffer();
                  DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")", brand );
@@ -69,7 +69,7 @@ index 4c03bfb2..552b0b17 100644
              // changes in the packet are ignored so we need to send it manually
              con.unsafe().sendPacket( pluginMessage );
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index afc2c12a..c0f7980b 100644
+index 1533eadc..a715ec8a 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 @@ -49,9 +49,9 @@ import net.md_5.bungee.protocol.Varint21LengthFieldPrepender;
@@ -86,5 +86,5 @@ index afc2c12a..c0f7980b 100644
      {
          @Override
 -- 
-2.30.1
+2.31.1.windows.1
 

--- a/BungeeCord-Patches/0012-Add-support-for-FML-with-IP-Forwarding-enabled.patch
+++ b/BungeeCord-Patches/0012-Add-support-for-FML-with-IP-Forwarding-enabled.patch
@@ -1,4 +1,4 @@
-From 3f85496f112fdc8f39a95ecfd06accea2ae2969b Mon Sep 17 00:00:00 2001
+From de6b5ced51ba9b31d9c26aa9aea7224434b365cc Mon Sep 17 00:00:00 2001
 From: Daniel Naylor <git@drnaylor.co.uk>
 Date: Tue, 25 Oct 2016 12:23:07 -0400
 Subject: [PATCH] Add support for FML with IP Forwarding enabled
@@ -12,7 +12,7 @@ However, there is now at least one Forge coremod that intends to support IP forw
 No breaking changes occur due to this patch.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 94b3e7ad..bafd741b 100644
+index 795ba6b6..2762aede 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -5,6 +5,7 @@ import io.netty.buffer.ByteBuf;
@@ -23,8 +23,8 @@ index 94b3e7ad..bafd741b 100644
  import java.util.Queue;
  import java.util.Set;
  import java.util.UUID;
-@@ -105,15 +106,39 @@ public class ServerConnector extends PacketHandler
-             String newHost = copiedHandshake.getHost() + "\00" + user.getAddress().getHostString() + "\00" + user.getUUID();
+@@ -106,15 +107,39 @@ public class ServerConnector extends PacketHandler
+             String newHost = copiedHandshake.getHost() + "\00" + AddressUtil.sanitizeAddress( user.getAddress() ) + "\00" + user.getUUID();
  
              LoginResult profile = user.getPendingConnection().getLoginProfile();
 +
@@ -100,5 +100,5 @@ index 6dca2048..f5253b89 100644
       * The FML 1.8 handshake token.
       */
 -- 
-2.31.1
+2.31.1.windows.1
 

--- a/BungeeCord-Patches/0017-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0017-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From ec9c98165375395d0ab4726f8b56182495682203 Mon Sep 17 00:00:00 2001
+From 13cfd996d8e278f969fc503fffc5773219584361 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -66,7 +66,7 @@ index de94bfda..4b16a50f 100644
                  throw new BadPacketException( "Packet with id " + id + " outside of range " );
              }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index bafd741b..4d0fa540 100644
+index 2762aede..a8516462 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -32,7 +32,9 @@ import net.md_5.bungee.forge.ForgeUtils;
@@ -79,7 +79,7 @@ index bafd741b..4d0fa540 100644
  import net.md_5.bungee.protocol.PacketWrapper;
  import net.md_5.bungee.protocol.Protocol;
  import net.md_5.bungee.protocol.ProtocolConstants;
-@@ -205,6 +207,12 @@ public class ServerConnector extends PacketHandler
+@@ -206,6 +208,12 @@ public class ServerConnector extends PacketHandler
  
          ServerConnection server = new ServerConnection( ch, target );
          ServerConnectedEvent event = new ServerConnectedEvent( user, server );
@@ -122,5 +122,5 @@ index 93989ee9..2e6cf764 100644
          {
              rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
 -- 
-2.31.1
+2.31.1.windows.1
 

--- a/BungeeCord-Patches/0020-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0020-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From d1dfa00c6432e63e237cce989cc336b1df712b5d Mon Sep 17 00:00:00 2001
+From 2137593b8852107c9195a5f0995d53fb9499f0b8 Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -7,10 +7,10 @@ This functionality of this patch was adopted upstream, however, this
 patch remains for a few misc improvements around here
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 4d0fa540..8a5eae3a 100644
+index a8516462..4c45c102 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -450,6 +450,6 @@ public class ServerConnector extends PacketHandler
+@@ -451,6 +451,6 @@ public class ServerConnector extends PacketHandler
      @Override
      public String toString()
      {
@@ -31,7 +31,7 @@ index a859195e..b9783a4c 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index c2cebd6b..fb410f20 100644
+index 1f91fe92..b99856fb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 @@ -653,20 +653,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
@@ -69,5 +69,5 @@ index 49fec0d7..a2f36f23 100644
      }
  }
 -- 
-2.30.1
+2.31.1.windows.1
 

--- a/BungeeCord-Patches/0027-Improve-ServerKickEvent.patch
+++ b/BungeeCord-Patches/0027-Improve-ServerKickEvent.patch
@@ -1,4 +1,4 @@
-From 686623652c10c78317a260bedb8d11ec5c47bacf Mon Sep 17 00:00:00 2001
+From c6c1164448a67e3b72752fc638f1033137571264 Mon Sep 17 00:00:00 2001
 From: Nathan Poirier <nathan@poirier.io>
 Date: Tue, 28 Jun 2016 23:00:49 -0500
 Subject: [PATCH] Improve ServerKickEvent
@@ -62,10 +62,10 @@ index 0e1ef5c4..ee63732d 100644
      @Deprecated
      public String getKickReason()
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 8a5eae3a..f304f991 100644
+index 4c45c102..84e93b38 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -367,7 +367,7 @@ public class ServerConnector extends PacketHandler
+@@ -368,7 +368,7 @@ public class ServerConnector extends PacketHandler
      public void handle(Kick kick) throws Exception
      {
          ServerInfo def = user.updateAndGetNextServer( target );
@@ -146,5 +146,5 @@ index b9783a4c..757a595b 100644
          {
              con.connectNow( event.getCancelServer(), ServerConnectEvent.Reason.KICK_REDIRECT );
 -- 
-2.30.1
+2.31.1.windows.1
 

--- a/BungeeCord-Patches/0046-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0046-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From e2aa832097ee0d8f09cd8b84ec1a6dc11dcacebb Mon Sep 17 00:00:00 2001
+From 4c120e1cb0579c52efcbaf85f281f770efaf21aa Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -57,10 +57,10 @@ index 4ff8da6d..e860214f 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index f304f991..2d9c0cda 100644
+index 84e93b38..a5efb0af 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -230,7 +230,7 @@ public class ServerConnector extends PacketHandler
+@@ -231,7 +231,7 @@ public class ServerConnector extends PacketHandler
              ch.write( message );
          }
  
@@ -69,7 +69,7 @@ index f304f991..2d9c0cda 100644
          {
              ch.write( user.getSettings() );
          }
-@@ -283,6 +283,7 @@ public class ServerConnector extends PacketHandler
+@@ -284,6 +284,7 @@ public class ServerConnector extends PacketHandler
              user.getTabListHandler().onServerChange();
  
              Scoreboard serverScoreboard = user.getServerSentScoreboard();
@@ -77,7 +77,7 @@ index f304f991..2d9c0cda 100644
              for ( Objective objective : serverScoreboard.getObjectives() )
              {
                  user.unsafe().sendPacket( new ScoreboardObjective( objective.getName(), objective.getValue(), ScoreboardObjective.HealthDisplay.fromString( objective.getType() ), (byte) 1 ) );
-@@ -295,6 +296,7 @@ public class ServerConnector extends PacketHandler
+@@ -296,6 +297,7 @@ public class ServerConnector extends PacketHandler
              {
                  user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.Team( team.getName() ) );
              }
@@ -85,7 +85,7 @@ index f304f991..2d9c0cda 100644
              serverScoreboard.clear();
  
              for ( UUID bossbar : user.getSentBossBars() )
-@@ -313,12 +315,35 @@ public class ServerConnector extends PacketHandler
+@@ -314,12 +316,35 @@ public class ServerConnector extends PacketHandler
              }
  
              user.setDimensionChange( true );
@@ -234,5 +234,5 @@ index 00000000..cb81d1dd
 +// Waterfall end
 \ No newline at end of file
 -- 
-2.31.1
+2.31.1.windows.1
 

--- a/BungeeCord-Patches/0048-Use-proper-max-length-for-serverbound-chat-packet.patch
+++ b/BungeeCord-Patches/0048-Use-proper-max-length-for-serverbound-chat-packet.patch
@@ -1,4 +1,4 @@
-From fb684fc6e09c86d84c6b6047901ad3f6b447fd41 Mon Sep 17 00:00:00 2001
+From 642d3af7c2e2537c49af02090b2ff7f17424c5e9 Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Wed, 20 Mar 2019 21:39:12 -0700
 Subject: [PATCH] Use proper max length for serverbound chat packet
@@ -30,25 +30,10 @@ index 0cef9430..d51a3142 100644
      {
          if ( b.length > Short.MAX_VALUE )
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
-index f886fe6e..c387802d 100644
+index e3a4d250..4749a671 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/Chat.java
-@@ -40,7 +40,13 @@ public class Chat extends DefinedPacket
-     @Override
-     public void read(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
-     {
--        message = readString( buf, ( direction == ProtocolConstants.Direction.TO_CLIENT ) ? Short.MAX_VALUE : 256 );
-+        // Waterfall start
-+        if (direction == ProtocolConstants.Direction.TO_CLIENT) {
-+            this.message = readString(buf, Short.MAX_VALUE * 8 + 8);
-+        } else {
-+            message = readString( buf, 256 );
-+        }
-+        // Waterfall end
-         if ( direction == ProtocolConstants.Direction.TO_CLIENT )
-         {
-             position = buf.readByte();
-@@ -54,6 +60,11 @@ public class Chat extends DefinedPacket
+@@ -54,6 +54,11 @@ public class Chat extends DefinedPacket
      @Override
      public void write(ByteBuf buf, ProtocolConstants.Direction direction, int protocolVersion)
      {
@@ -61,5 +46,5 @@ index f886fe6e..c387802d 100644
          if ( direction == ProtocolConstants.Direction.TO_CLIENT )
          {
 -- 
-2.31.1
+2.31.1.windows.1
 


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
39a80e41 #3093: Support names with '.', block names with ' '
ab9153dd Further increase length limit for TO_CLIENT chat packets
7ec1f487 Remove ipv6 scope from forwarded addresses