### PR TITLE
Enable 1.17 Release-protocol

### DIFF
--- a/BungeeCord-Patches/0062-Enable-1.17-Release-protocol.patch
+++ b/BungeeCord-Patches/0062-Enable-1.17-Release-protocol.patch
@@ -1,0 +1,58 @@
+From 92225852393f5b5d21f6365d1e4aa2237b359501 Mon Sep 17 00:00:00 2001
+From: FivePB <admin@fivepb.me>
+Date: Fri, 4 Jun 2021 13:56:15 +0200
+Subject: [PATCH] Enable 1.17 Release-protocol
+
+
+diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
+index 8c3a78d6..8c021273 100644
+--- a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
++++ b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
+@@ -6,7 +6,6 @@ import java.util.List;
+ public class ProtocolConstants
+ {
+ 
+-    private static final boolean SNAPSHOT_SUPPORT = Boolean.getBoolean( "net.md_5.bungee.protocol.snapshot" );
+     public static final int MINECRAFT_1_8 = 47;
+     public static final int MINECRAFT_1_9 = 107;
+     public static final int MINECRAFT_1_9_1 = 108;
+@@ -34,7 +33,7 @@ public class ProtocolConstants
+     public static final int MINECRAFT_1_16_2 = 751;
+     public static final int MINECRAFT_1_16_3 = 753;
+     public static final int MINECRAFT_1_16_4 = 754;
+-    public static final int MINECRAFT_1_17 = 1073741852;
++    public static final int MINECRAFT_1_17 = 755;
+     public static final List<String> SUPPORTED_VERSIONS;
+     public static final List<Integer> SUPPORTED_VERSION_IDS;
+ 
+@@ -49,7 +48,8 @@ public class ProtocolConstants
+                 "1.13.x",
+                 "1.14.x",
+                 "1.15.x",
+-                "1.16.x"
++                "1.16.x",
++                "1.17"
+         );
+         ImmutableList.Builder<Integer> supportedVersionIds = ImmutableList.<Integer>builder().add(
+                 ProtocolConstants.MINECRAFT_1_8,
+@@ -78,15 +78,10 @@ public class ProtocolConstants
+                 ProtocolConstants.MINECRAFT_1_16_1,
+                 ProtocolConstants.MINECRAFT_1_16_2,
+                 ProtocolConstants.MINECRAFT_1_16_3,
+-                ProtocolConstants.MINECRAFT_1_16_4
++                ProtocolConstants.MINECRAFT_1_16_4,
++                ProtocolConstants.MINECRAFT_1_17
+         );
+ 
+-        if ( SNAPSHOT_SUPPORT )
+-        {
+-            supportedVersions.add( "1.17.x" );
+-            supportedVersionIds.add( ProtocolConstants.MINECRAFT_1_17 );
+-        }
+-
+         SUPPORTED_VERSIONS = supportedVersions.build();
+         SUPPORTED_VERSION_IDS = supportedVersionIds.build();
+     }
+-- 
+2.25.1
+


### PR DESCRIPTION
I don't expect there to be more changes that will impact the network logic Waterfall needs to function, so we can have this early (hopefully)