### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0019-Add-basic-support-for-configurable-tab-complete-thro.patch
+++ b/BungeeCord-Patches/0019-Add-basic-support-for-configurable-tab-complete-thro.patch
@@ -1,4 +1,4 @@
-From 7ec9385c6596308ff25a88e8f9aecacce695d2a5 Mon Sep 17 00:00:00 2001
+From 01a6d8e243359fac4e4b6c2140e6c13ca707699b Mon Sep 17 00:00:00 2001
 From: Johannes Donath <johannesd@torchmind.com>
 Date: Sat, 4 Jul 2015 06:31:33 +0200
 Subject: [PATCH] Add basic support for configurable tab-complete throttling
@@ -73,7 +73,7 @@ index 741ebfde..91743f01 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index f150d8fa..49fec0d7 100644
+index 5f7f3c4d..d0afb7c7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 @@ -39,6 +39,8 @@ public class UpstreamBridge extends PacketHandler
@@ -85,7 +85,7 @@ index f150d8fa..49fec0d7 100644
      public UpstreamBridge(ProxyServer bungee, UserConnection con)
      {
          this.bungee = bungee;
-@@ -162,6 +164,20 @@ public class UpstreamBridge extends PacketHandler
+@@ -165,6 +167,20 @@ public class UpstreamBridge extends PacketHandler
      @Override
      public void handle(TabCompleteRequest tabComplete) throws Exception
      {
@@ -107,5 +107,5 @@ index f150d8fa..49fec0d7 100644
  
          if ( tabComplete.getCursor().startsWith( "/" ) )
 -- 
-2.24.0
+2.31.1.windows.1
 

--- a/BungeeCord-Patches/0020-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0020-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From 2137593b8852107c9195a5f0995d53fb9499f0b8 Mon Sep 17 00:00:00 2001
+From c122e52187ca439d31d2e5a242e12a6af1de97b3 Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -57,10 +57,10 @@ index 1f91fe92..b99856fb 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 49fec0d7..a2f36f23 100644
+index d0afb7c7..e64b0ce4 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -276,6 +276,6 @@ public class UpstreamBridge extends PacketHandler
+@@ -279,6 +279,6 @@ public class UpstreamBridge extends PacketHandler
      @Override
      public String toString()
      {

--- a/BungeeCord-Patches/0024-Validate-that-chat-messages-are-non-blank.patch
+++ b/BungeeCord-Patches/0024-Validate-that-chat-messages-are-non-blank.patch
@@ -1,4 +1,4 @@
-From 76e7f32f689d050b70f77d3a28f41e86f242890a Mon Sep 17 00:00:00 2001
+From 28979e8c43ff7d6244d9e450cfb8e55cedf17a37 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Tue, 25 Oct 2016 12:34:41 -0400
 Subject: [PATCH] Validate that chat messages are non-blank
@@ -33,7 +33,7 @@ index 00000000..940ad806
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index a2f36f23..4d7b1b23 100644
+index e64b0ce4..63b82687 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 @@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
@@ -44,14 +44,15 @@ index a2f36f23..4d7b1b23 100644
  import io.netty.channel.Channel;
  import java.util.ArrayList;
  import java.util.LinkedList;
-@@ -148,6 +149,7 @@ public class UpstreamBridge extends PacketHandler
+@@ -146,6 +147,8 @@ public class UpstreamBridge extends PacketHandler
+     @Override
+     public void handle(Chat chat) throws Exception
      {
-         int maxLength = ( con.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_11 ) ? 256 : 100;
-         Preconditions.checkArgument( chat.getMessage().length() <= maxLength, "Chat message too long" ); // Mojang limit, check on updates
 +        Preconditions.checkArgument(!StringUtil.isBlank(chat.getMessage()), "Chat message is empty");
- 
-         ChatEvent chatEvent = new ChatEvent( con, con.getServer(), chat.getMessage() );
-         if ( !bungee.getPluginManager().callEvent( chatEvent ).isCancelled() )
++
+         for ( int index = 0, length = chat.getMessage().length(); index < length; index++ )
+         {
+             char c = chat.getMessage().charAt( index );
 -- 
-2.24.0
+2.31.1.windows.1
 


### PR DESCRIPTION
* Check chat for illegal chars & moved length check into the packet class

I had to fix some compilation issues related to the move of the chat message length check.