### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0008-Fixup-ProtocolConstants.patch
+++ b/BungeeCord-Patches/0008-Fixup-ProtocolConstants.patch
@@ -1,14 +1,14 @@
-From 53fb011bb76cebe76173da7e45055d750247f0b1 Mon Sep 17 00:00:00 2001
+From 4026d8133ccba5176f53f6e9ff695911e17fa508 Mon Sep 17 00:00:00 2001
 From: Troy Frew <fuzzy_bot@arenaga.me>
 Date: Tue, 15 Nov 2016 09:07:51 -0500
 Subject: [PATCH] Fixup ProtocolConstants
 
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
-index b9f1ff08..e208209e 100644
+index ce9e5298..caf7ed0b 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
-@@ -93,6 +93,16 @@ public class ProtocolConstants
+@@ -95,6 +95,16 @@ public class ProtocolConstants
          SUPPORTED_VERSION_IDS = supportedVersionIds.build();
      }
  
@@ -26,5 +26,5 @@ index b9f1ff08..e208209e 100644
      {
  
 -- 
-2.30.0
+2.28.0.windows.1
 

--- a/BungeeCord-Patches/0017-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0017-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From 2129b8a17d2352058ee2cb5142c99e4023d3d90c Mon Sep 17 00:00:00 2001
+From 649161b8c66503d01ca6601d110e5209d068582e Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -105,10 +105,10 @@ index 8979ac22..d4348eb7 100644
      @Getter
      @NonNull
 diff --git a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-index 93989ee9..2e6cf764 100644
+index 3f18393f..572e1c47 100644
 --- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 +++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-@@ -324,6 +324,12 @@ public abstract class EntityMap
+@@ -325,6 +325,12 @@ public abstract class EntityMap
          int packetId = DefinedPacket.readVarInt( packet );
          int packetIdLength = packet.readerIndex() - readerIndex;
  
@@ -122,5 +122,5 @@ index 93989ee9..2e6cf764 100644
          {
              rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
 -- 
-2.30.1 (Apple Git-130)
+2.28.0.windows.1
 

--- a/BungeeCord-Patches/0046-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0046-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From 397d497cb913737fd6190775efae10b55a48f109 Mon Sep 17 00:00:00 2001
+From 8bc317f3d6b8ef341fc3bd129bd78c80f371c629 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -158,7 +158,7 @@ index 033877fc..72b6e9be 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-index 2e6cf764..13456b34 100644
+index 572e1c47..09df5a93 100644
 --- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 +++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 @@ -6,6 +6,7 @@ import io.netty.buffer.ByteBufInputStream;
@@ -181,7 +181,7 @@ index 2e6cf764..13456b34 100644
          switch ( version )
          {
              case ProtocolConstants.MINECRAFT_1_8:
-@@ -286,7 +292,13 @@ public abstract class EntityMap
+@@ -287,7 +293,13 @@ public abstract class EntityMap
                      DefinedPacket.readVarInt( packet );
                      break;
                  default:
@@ -234,5 +234,5 @@ index 00000000..cb81d1dd
 +// Waterfall end
 \ No newline at end of file
 -- 
-2.30.1 (Apple Git-130)
+2.28.0.windows.1
 


### PR DESCRIPTION
~~Supports upcoming 1.17.1 protocol.~~

~~There is no significant protocol difference between 1.17 and 1.17.1 snapshots, so adding a protocol ID can expect normal operation.~~

~~This patch should be either removed or close(PR) when BungeeCord supports 1.17.1~~

Bungeecord 1.17.1 has been released. Switch this PR to an upstream update.