### PR TITLE
Strip hostname from InetSocketAddress

### DIFF
--- a/BungeeCord-Patches/0061-Strip-hostname-from-InetSocketAddress.patch
+++ b/BungeeCord-Patches/0061-Strip-hostname-from-InetSocketAddress.patch
@@ -1,0 +1,55 @@
+From 1b1107674563adebad11d00b6625bf8f6cbb97d1 Mon Sep 17 00:00:00 2001
+From: mibac138 <5672750+mibac138@users.noreply.github.com>
+Date: Tue, 20 Jul 2021 00:47:59 +0200
+Subject: [PATCH] Strip hostname from InetSocketAddress
+
+Recently PaperSpigot added a host check that doesn't allow hostnames
+in ip addresses and if a hostname is present then it kicks the player
+with a configure ip forwarding in bungee to connect error message.
+By default Bungee doesn't actually include the hostname (as to include
+it you need to call getHostName which triggers reverse service lookups
+that add the hostname info). However, the only thing a bungee plugin
+needs to do is to call addr.getHostName() in PlayerLoginEvent to
+trigger this and block the player from joining any recent paper servers.
+This change strips the hostname from the ip address sent to the proxied
+server thus fixing this issue. Example address sent before:
+`123.123.123.123.ipv4.supernova.orange.pl`
+after:
+`123.123.123.123`.
+
+Context:
+hi! i have a papermc 1.16.5 and bungeecord server. i updated papermc and
+the server started rejecting me saying i need to configure If you wish
+to use IP forwarding, please enable it in your BungeeCord config as
+well but everything in config was good. so i started digging and
+found out papermc added a host_check like this
+Pattern HOST_PATTERN = Pattern.compile("[0-9a-f\\.:]{0,45}");
+If this pattern doesn't match the hostname in
+PacketHandshakeSetProtocol, the server kicks the user with the above
+message. In debug I saw that my hostname looks like this:
+123.123.123.123.ipv4.supernova.orange.pl. I messaged papermc about this
+and they said an dns resolved ip like this should not be possible.
+I started digging in bungeecord and found out an innocent plugin that
+called getConnection().getAddress().getHostName() caused the address to
+gain the ipv4..... suffix (getHostName does that under the hood).
+I once again contacted paper devs about this and was told this is a
+bungeecord issue, and its not on their side. So, long story short,
+when connecting to a proxied server you need to make sure not to send
+the host name
+
+diff --git a/proxy/src/main/java/net/md_5/bungee/util/AddressUtil.java b/proxy/src/main/java/net/md_5/bungee/util/AddressUtil.java
+index 03dabe01..464acc6c 100644
+--- a/proxy/src/main/java/net/md_5/bungee/util/AddressUtil.java
++++ b/proxy/src/main/java/net/md_5/bungee/util/AddressUtil.java
+@@ -11,7 +11,7 @@ public class AddressUtil
+
+     public static String sanitizeAddress(InetSocketAddress addr)
+     {
+-        String string = addr.getHostString();
++        String string = addr.getAddress().getHostAddress(); // Waterfall
+
+         // Remove IPv6 scope if present
+         if ( addr.getAddress() instanceof Inet6Address )
+--
+2.25.1
+


### PR DESCRIPTION
Recently PaperSpigot added a host check that doesn't allow hostnames
in ip addresses and if a hostname is present then it kicks the player
with a configure ip forwarding in bungee to connect error message.
By default Bungee doesn't actually include the hostname (as to include
it you need to call getHostName which triggers reverse service lookups
that add the hostname info). However, the only thing a bungee plugin
needs to do is to call addr.getHostName() in PlayerLoginEvent to
trigger this and block the player from joining any recent paper servers.
This change strips the hostname from the ip address sent to the proxied
server thus fixing this issue. Example address sent before:
`123.123.123.123.ipv4.supernova.orange.pl`
after:
`123.123.123.123`.

Context:
hi! i have a papermc 1.16.5 and bungeecord server. i updated papermc and
the server started rejecting me saying i need to configure If you wish
to use IP forwarding, please enable it in your BungeeCord config as
well but everything in config was good. so i started digging and
found out papermc added a host_check like this
Pattern HOST_PATTERN = Pattern.compile("[0-9a-f\\.:]{0,45}");
If this pattern doesn't match the hostname in
PacketHandshakeSetProtocol, the server kicks the user with the above
message. In debug I saw that my hostname looks like this:
123.123.123.123.ipv4.supernova.orange.pl. I messaged papermc about this
and they said an dns resolved ip like this should not be possible.
I started digging in bungeecord and found out an innocent plugin that
called getConnection().getAddress().getHostName() caused the address to
gain the ipv4..... suffix (getHostName does that under the hood).
I once again contacted paper devs about this and was told this is a
bungeecord issue, and its not on their side. So, long story short,
when connecting to a proxied server you need to make sure not to send
the host name