### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0018-Add-basic-support-for-configurable-tab-complete-thro.patch
+++ b/BungeeCord-Patches/0018-Add-basic-support-for-configurable-tab-complete-thro.patch
@@ -1,4 +1,4 @@
-From 78af2898f522c9819132e8fac9bed8d067a61b01 Mon Sep 17 00:00:00 2001
+From 441be0a40b0298e8e5f2c66a337d365f9ec1c065 Mon Sep 17 00:00:00 2001
 From: Johannes Donath <johannesd@torchmind.com>
 Date: Sat, 4 Jul 2015 06:31:33 +0200
 Subject: [PATCH] Add basic support for configurable tab-complete throttling
@@ -73,7 +73,7 @@ index 741ebfde..91743f01 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 41101a6e..4ed24626 100644
+index 253c3287..079ae5a0 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 @@ -40,6 +40,8 @@ public class UpstreamBridge extends PacketHandler
@@ -104,8 +104,8 @@ index 41101a6e..4ed24626 100644
 +
 +        // Waterfall end - tab limiter
          List<String> suggestions = new ArrayList<>();
+         boolean isRegisteredCommand = false;
  
-         if ( tabComplete.getCursor().startsWith( "/" ) )
 -- 
 2.30.1 (Apple Git-130)
 

--- a/BungeeCord-Patches/0019-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0019-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From 23c179769cebc81eaeccc4774e26e9e92f777996 Mon Sep 17 00:00:00 2001
+From 05afdcfffbebb56f1742713115784729d54d7b7c Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -57,10 +57,10 @@ index 25406d82..646e07f4 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 4ed24626..30623743 100644
+index 079ae5a0..02f5661f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -284,6 +284,6 @@ public class UpstreamBridge extends PacketHandler
+@@ -291,6 +291,6 @@ public class UpstreamBridge extends PacketHandler
      @Override
      public String toString()
      {


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
c3fffbc9 #3205: Don't forward tab completions if the root command is a bungee command
