### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
+++ b/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
@@ -1,4 +1,4 @@
-From 1a5e92a62801a3c7ee5093b73ae1d963579b8472 Mon Sep 17 00:00:00 2001
+From d465f043c5f09769e7e2cacb6f450ec496eeb62e Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 3 May 2016 20:31:52 -0700
 Subject: [PATCH] Don't access a ByteBuf's underlying array
@@ -6,19 +6,19 @@ Subject: [PATCH] Don't access a ByteBuf's underlying array
 It returns the underlying array storage, and does *not* return a view of the buffer as an array
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
-index af16ead8..c652ffb4 100644
+index 6f9fc6c3..4f3a8c72 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
-@@ -4,6 +4,7 @@ import com.google.common.base.Function;
+@@ -3,6 +3,7 @@ package net.md_5.bungee.protocol.packet;
+ import com.google.common.base.Function;
  import com.google.common.base.Preconditions;
- import com.google.common.base.Predicate;
  import io.netty.buffer.ByteBuf;
 +import io.netty.buffer.ByteBufUtil; // Waterfall
  import java.io.ByteArrayInputStream;
  import java.io.DataInput;
  import java.io.DataInputStream;
-@@ -56,10 +57,23 @@ public class PluginMessage extends DefinedPacket
-             return ( input.getTag().equals( "REGISTER" ) || input.getTag().equals( "minecraft:register" ) || input.getTag().equals( "MC|Brand" ) || input.getTag().equals( "minecraft:brand" ) ) && input.getData().length < Byte.MAX_VALUE;
+@@ -47,10 +48,23 @@ public class PluginMessage extends DefinedPacket
+             return "legacy:" + tag.toLowerCase( Locale.ROOT );
          }
      };
 -    //
@@ -43,10 +43,10 @@ index af16ead8..c652ffb4 100644
       * Allow this packet to be sent as an "extended" packet.
       */
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 7b705d99..b4661cfb 100644
+index 7c082d46..5c74d5f1 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -240,7 +240,7 @@ public class ServerConnector extends PacketHandler
+@@ -249,7 +249,7 @@ public class ServerConnector extends PacketHandler
              {
                  ByteBuf brand = ByteBufAllocator.DEFAULT.heapBuffer();
                  DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")", brand );
@@ -86,5 +86,5 @@ index 1533eadc..a715ec8a 100644
      {
          @Override
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0010-Optimize-uuid-conversions.patch
+++ b/BungeeCord-Patches/0010-Optimize-uuid-conversions.patch
@@ -1,4 +1,4 @@
-From 45fdbf7edc81e2610a939e208d4cdd7570792cf9 Mon Sep 17 00:00:00 2001
+From 89ccd74999f91c9f795e60c083017a1dc74c3e02 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Mon, 14 Mar 2016 15:40:44 -0700
 Subject: [PATCH] Optimize uuid conversions
@@ -251,10 +251,10 @@ index 88d36ad2..fc92a7b5 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index cc40fe1b..25406d82 100644
+index 89f2d9fe..c254379a 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -641,7 +641,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -640,7 +640,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      @Override
      public String getUUID()
      {
@@ -264,5 +264,5 @@ index cc40fe1b..25406d82 100644
  
      @Override
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch
+++ b/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch
@@ -1,4 +1,4 @@
-From 9ae310722ce5ad06451042bd7eb7a47a8cd19403 Mon Sep 17 00:00:00 2001
+From a3f6e1ecf7c446d79590e050cd5360ea6c806af1 Mon Sep 17 00:00:00 2001
 From: Daniel Naylor <git@drnaylor.co.uk>
 Date: Tue, 25 Oct 2016 12:23:07 -0400
 Subject: [PATCH] Add support for FML with IP Forwarding enabled
@@ -12,18 +12,18 @@ However, there is now at least one Forge coremod that intends to support IP forw
 No breaking changes occur due to this patch.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index b4661cfb..1f4cd068 100644
+index 5c74d5f1..d1715b9c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -5,6 +5,7 @@ import io.netty.buffer.ByteBuf;
- import io.netty.buffer.ByteBufAllocator;
+@@ -7,6 +7,7 @@ import io.netty.buffer.ByteBufAllocator;
  import java.net.InetSocketAddress;
+ import java.nio.charset.StandardCharsets;
  import java.util.Locale;
 +import java.util.Arrays; // Waterfall
  import java.util.Queue;
  import java.util.Set;
  import java.util.UUID;
-@@ -106,15 +107,39 @@ public class ServerConnector extends PacketHandler
+@@ -108,15 +109,39 @@ public class ServerConnector extends PacketHandler
              String newHost = copiedHandshake.getHost() + "\00" + AddressUtil.sanitizeAddress( user.getAddress() ) + "\00" + user.getUUID();
  
              LoginResult profile = user.getPendingConnection().getLoginProfile();
@@ -100,5 +100,5 @@ index 6dca2048..f5253b89 100644
       * The FML 1.8 handshake token.
       */
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From d3adc851b7f3a6c361612b477805af38a5ce4b53 Mon Sep 17 00:00:00 2001
+From fe301104656417e3c8e22538170a3fb75518e669 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -66,10 +66,10 @@ index 9c8a7118..220365dd 100644
                  throw new BadPacketException( "Packet with id " + id + " outside of range" );
              }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 1f4cd068..152a2b65 100644
+index d1715b9c..0825a5a1 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -32,7 +32,9 @@ import net.md_5.bungee.forge.ForgeUtils;
+@@ -34,7 +34,9 @@ import net.md_5.bungee.forge.ForgeUtils;
  import net.md_5.bungee.netty.ChannelWrapper;
  import net.md_5.bungee.netty.HandlerBoss;
  import net.md_5.bungee.netty.PacketHandler;
@@ -79,7 +79,7 @@ index 1f4cd068..152a2b65 100644
  import net.md_5.bungee.protocol.PacketWrapper;
  import net.md_5.bungee.protocol.Protocol;
  import net.md_5.bungee.protocol.ProtocolConstants;
-@@ -206,6 +208,12 @@ public class ServerConnector extends PacketHandler
+@@ -208,6 +210,12 @@ public class ServerConnector extends PacketHandler
  
          ServerConnection server = new ServerConnection( ch, target );
          ServerConnectedEvent event = new ServerConnectedEvent( user, server );
@@ -122,5 +122,5 @@ index 23715f68..7d970ad8 100644
          {
              rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0019-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0019-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From 05afdcfffbebb56f1742713115784729d54d7b7c Mon Sep 17 00:00:00 2001
+From 7f0cf613be361f1370bad6bd97e28f7d2d6049ef Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -7,10 +7,10 @@ This functionality of this patch was adopted upstream, however, this
 patch remains for a few misc improvements around here
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 152a2b65..6d5c4255 100644
+index 0825a5a1..175150c7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -451,6 +451,6 @@ public class ServerConnector extends PacketHandler
+@@ -460,6 +460,6 @@ public class ServerConnector extends PacketHandler
      @Override
      public String toString()
      {
@@ -31,10 +31,10 @@ index d9facc62..dd742d01 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 25406d82..646e07f4 100644
+index c254379a..465fb3c1 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -647,20 +647,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -646,20 +646,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      @Override
      public String toString()
      {
@@ -57,10 +57,10 @@ index 25406d82..646e07f4 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 079ae5a0..02f5661f 100644
+index 5b58fdea..af19796f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -291,6 +291,6 @@ public class UpstreamBridge extends PacketHandler
+@@ -287,6 +287,6 @@ public class UpstreamBridge extends PacketHandler
      @Override
      public String toString()
      {
@@ -69,5 +69,5 @@ index 079ae5a0..02f5661f 100644
      }
  }
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0020-Add-a-property-to-accept-invalid-ping-packets.patch
+++ b/BungeeCord-Patches/0020-Add-a-property-to-accept-invalid-ping-packets.patch
@@ -1,4 +1,4 @@
-From 34b679a4c08490fe3aebd16be3fde4510c760e46 Mon Sep 17 00:00:00 2001
+From 46b9593c1f86d88fee2dbf10646a0ba823131b08 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Sun, 7 Feb 2016 00:01:19 -0700
 Subject: [PATCH] Add a property to accept invalid ping packets
@@ -9,10 +9,10 @@ You can enable it by setting '-Dwaterfall.acceptInvalidPackets=true' at the comm
 Fixes #23
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 646e07f4..d823a718 100644
+index 465fb3c1..61e8e9a7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -278,10 +278,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -277,10 +277,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          thisState = State.PING;
      }
  
@@ -29,5 +29,5 @@ index 646e07f4..d823a718 100644
          disconnect( "" );
      }
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0026-Improve-ServerKickEvent.patch
+++ b/BungeeCord-Patches/0026-Improve-ServerKickEvent.patch
@@ -1,4 +1,4 @@
-From 6cd968fe423be552cb5044f6c147f732c27d6416 Mon Sep 17 00:00:00 2001
+From 8820915bd0c7783f42ac4f0eca4da2d9b03fe97d Mon Sep 17 00:00:00 2001
 From: Nathan Poirier <nathan@poirier.io>
 Date: Tue, 28 Jun 2016 23:00:49 -0500
 Subject: [PATCH] Improve ServerKickEvent
@@ -62,10 +62,10 @@ index 0e1ef5c4..ee63732d 100644
      @Deprecated
      public String getKickReason()
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 6d5c4255..9b44f6a5 100644
+index 175150c7..5595278b 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -368,7 +368,7 @@ public class ServerConnector extends PacketHandler
+@@ -377,7 +377,7 @@ public class ServerConnector extends PacketHandler
      public void handle(Kick kick) throws Exception
      {
          ServerInfo def = user.updateAndGetNextServer( target );
@@ -146,5 +146,5 @@ index dd742d01..314b08bc 100644
          {
              con.connectNow( event.getCancelServer(), ServerConnectEvent.Reason.KICK_REDIRECT );
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0040-Providing-access-to-the-player-s-LoginResult-on-Logi.patch
+++ b/BungeeCord-Patches/0040-Providing-access-to-the-player-s-LoginResult-on-Logi.patch
@@ -1,4 +1,4 @@
-From 381e769107baef7b50d6d793177272b8e94d549f Mon Sep 17 00:00:00 2001
+From da23eb1af3034f77bc848a4a0ade1c73185ba9a1 Mon Sep 17 00:00:00 2001
 From: phenomax <phenomax@revayd.net>
 Date: Thu, 10 Aug 2017 18:41:17 +0200
 Subject: [PATCH] Providing access to the player's LoginResult on LoginEvent
@@ -52,10 +52,10 @@ similarity index 100%
 rename from proxy/src/main/java/net/md_5/bungee/connection/LoginResult.java
 rename to api/src/main/java/net/md_5/bungee/connection/LoginResult.java
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index d823a718..3c2dc475 100644
+index 61e8e9a7..8f34a575 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -555,7 +555,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -554,7 +554,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          };
  
          // fire login event
@@ -65,5 +65,5 @@ index d823a718..3c2dc475 100644
  
      @Override
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0041-Optionally-log-InitialHandler-connections.patch
+++ b/BungeeCord-Patches/0041-Optionally-log-InitialHandler-connections.patch
@@ -1,4 +1,4 @@
-From 09bfed1385492691961f84e2c1ad9550601716b2 Mon Sep 17 00:00:00 2001
+From 8a71e0d94cbfec7d165a5502a700ddc23d5e356b Mon Sep 17 00:00:00 2001
 From: Gabriele C <sgdc3.mail@gmail.com>
 Date: Thu, 8 Feb 2018 19:10:52 +0100
 Subject: [PATCH] Optionally log InitialHandler connections
@@ -61,10 +61,10 @@ index ef44d334..4ff8da6d 100644
      public String getGameVersion() {
          return gameVersion;
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 3c2dc475..80a66a2b 100644
+index 8f34a575..b634d256 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -332,7 +332,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -331,7 +331,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                  break;
              case 2:
                  // Login
@@ -77,5 +77,5 @@ index 3c2dc475..80a66a2b 100644
                  ch.setProtocol( Protocol.LOGIN );
  
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0045-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0045-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From 38e0957a49bfe1731d9b2373b8088629b0e8190f Mon Sep 17 00:00:00 2001
+From cc0e0d5dba2796f0ab090d54f600c578f93946de Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -57,11 +57,11 @@ index 4ff8da6d..e860214f 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 9b44f6a5..134d4356 100644
+index 5595278b..9e74d158 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -231,7 +231,7 @@ public class ServerConnector extends PacketHandler
-             ch.write( message );
+@@ -240,7 +240,7 @@ public class ServerConnector extends PacketHandler
+             ch.write( new PluginMessage( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13 ? "minecraft:register" : "REGISTER", Joiner.on( "\0" ).join( registeredChannels ).getBytes( StandardCharsets.UTF_8 ), false ) );
          }
  
 -        if ( user.getSettings() != null )
@@ -69,7 +69,7 @@ index 9b44f6a5..134d4356 100644
          {
              ch.write( user.getSettings() );
          }
-@@ -284,6 +284,7 @@ public class ServerConnector extends PacketHandler
+@@ -293,6 +293,7 @@ public class ServerConnector extends PacketHandler
              user.getTabListHandler().onServerChange();
  
              Scoreboard serverScoreboard = user.getServerSentScoreboard();
@@ -77,7 +77,7 @@ index 9b44f6a5..134d4356 100644
              for ( Objective objective : serverScoreboard.getObjectives() )
              {
                  user.unsafe().sendPacket( new ScoreboardObjective( objective.getName(), objective.getValue(), ScoreboardObjective.HealthDisplay.fromString( objective.getType() ), (byte) 1 ) );
-@@ -296,6 +297,7 @@ public class ServerConnector extends PacketHandler
+@@ -305,6 +306,7 @@ public class ServerConnector extends PacketHandler
              {
                  user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.Team( team.getName() ) );
              }
@@ -85,7 +85,7 @@ index 9b44f6a5..134d4356 100644
              serverScoreboard.clear();
  
              for ( UUID bossbar : user.getSentBossBars() )
-@@ -314,12 +316,35 @@ public class ServerConnector extends PacketHandler
+@@ -323,12 +325,35 @@ public class ServerConnector extends PacketHandler
              }
  
              user.setDimensionChange( true );
@@ -234,5 +234,5 @@ index 00000000..cb81d1dd
 +// Waterfall end
 \ No newline at end of file
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0050-Speed-up-some-common-exceptions.patch
+++ b/BungeeCord-Patches/0050-Speed-up-some-common-exceptions.patch
@@ -1,4 +1,4 @@
-From 4bd6ac47556d016ac1415c4d929107b8b7040f9b Mon Sep 17 00:00:00 2001
+From 8bcafa4ef75dec34e916726104eae43f65bd6df3 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 25 Nov 2019 19:54:06 +0000
 Subject: [PATCH] Speed up some common exceptions
@@ -146,10 +146,10 @@ index 8b7e0708..37d28c01 100644
          {
              if ( slice != null )
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 80a66a2b..d07f60c9 100644
+index b634d256..2d7101ff 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -12,6 +12,8 @@ import java.util.List;
+@@ -14,6 +14,8 @@ import java.util.Set;
  import java.util.UUID;
  import java.util.logging.Level;
  import javax.crypto.SecretKey;
@@ -158,7 +158,7 @@ index 80a66a2b..d07f60c9 100644
  import lombok.Getter;
  import lombok.RequiredArgsConstructor;
  import net.md_5.bungee.BungeeCord;
-@@ -420,6 +422,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -419,6 +421,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          Preconditions.checkState( thisState == State.ENCRYPT, "Not expecting ENCRYPT" );
  
          SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );
@@ -195,5 +195,5 @@ index ac99d02c..0c1ecfb8 100644
  
              // Waterfall start
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 

--- a/BungeeCord-Patches/0055-Add-auth-url-option.patch
+++ b/BungeeCord-Patches/0055-Add-auth-url-option.patch
@@ -1,14 +1,14 @@
-From 1da5defd28c4fad2c5b3448ea8ab4752ce2b4431 Mon Sep 17 00:00:00 2001
+From 24e8f66309237a5f4d54f49ffe7af021566c6ecd Mon Sep 17 00:00:00 2001
 From: theminecoder <theminecoder.dev@gmail.com>
 Date: Sun, 19 Jul 2020 10:18:23 +1000
 Subject: [PATCH] Add auth url option
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index d07f60c9..0fd58e83 100644
+index 2d7101ff..c3e60fa5 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -73,6 +73,8 @@ import net.md_5.bungee.util.QuietException;
+@@ -74,6 +74,8 @@ import net.md_5.bungee.util.QuietException;
  public class InitialHandler extends PacketHandler implements PendingConnection
  {
  
@@ -17,7 +17,7 @@ index d07f60c9..0fd58e83 100644
      private final BungeeCord bungee;
      private ChannelWrapper ch;
      @Getter
-@@ -448,7 +450,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -447,7 +449,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          String encodedHash = URLEncoder.encode( new BigInteger( sha.digest() ).toString( 16 ), "UTF-8" );
  
          String preventProxy = ( BungeeCord.getInstance().config.isPreventProxyConnections() && getSocketAddress() instanceof InetSocketAddress ) ? "&ip=" + URLEncoder.encode( getAddress().getAddress().getHostAddress(), "UTF-8" ) : "";
@@ -27,5 +27,5 @@ index d07f60c9..0fd58e83 100644
          Callback<String> handler = new Callback<String>()
          {
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
c7b0c3cd #3207: Rework the plugin message relaying system to allow unregisteri…
c0c9b285 Update snapshot support to 1.18-pre1