### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0001-POM-Changes.patch
+++ b/BungeeCord-Patches/0001-POM-Changes.patch
@@ -1,4 +1,4 @@
-From faa6ff1b3610328f224270cdc6db17d4505328eb Mon Sep 17 00:00:00 2001
+From 0e67fd377b8bb24b24252fb426beb45938d6b008 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 19:33:31 +0200
 Subject: [PATCH] POM Changes
@@ -7,7 +7,7 @@ Subject: [PATCH] POM Changes
 - Deploy to papermc mvn repo
 
 diff --git a/api/pom.xml b/api/pom.xml
-index a8ed49ed..adc91449 100644
+index f291fb2e..65ede623 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -4,42 +4,42 @@
@@ -175,7 +175,7 @@ index 0c244852..0ad5dd16 100644
      <dependencies>
          <dependency>
 diff --git a/config/pom.xml b/config/pom.xml
-index a6f34c99..011d3ce7 100644
+index 318ea6ef..2caffc27 100644
 --- a/config/pom.xml
 +++ b/config/pom.xml
 @@ -4,19 +4,19 @@
@@ -483,7 +483,7 @@ index aa62ce2a..1eff2c93 100644
      <dependencies>
          <dependency>
 diff --git a/pom.xml b/pom.xml
-index 311db811..d90a79fb 100644
+index c638ef32..a9070b46 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,18 +3,25 @@
@@ -579,8 +579,8 @@ index 311db811..d90a79fb 100644
 +        </snapshotRepository>
      </distributionManagement>
  
-     <properties>
-@@ -124,12 +139,21 @@
+     <!-- We really shouldn't depend on external repositories, but at least this is the Central staging one -->
+@@ -139,12 +154,21 @@
                      </execution>
                  </executions>
              </plugin>
@@ -602,7 +602,7 @@ index 311db811..d90a79fb 100644
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-checkstyle-plugin</artifactId>
                  <version>3.1.2</version>
-@@ -154,6 +178,7 @@
+@@ -169,6 +193,7 @@
                      </dependency>
                  </dependencies>
              </plugin>
@@ -610,7 +610,7 @@ index 311db811..d90a79fb 100644
              <plugin>
                  <groupId>org.codehaus.mojo</groupId>
                  <artifactId>animal-sniffer-maven-plugin</artifactId>
-@@ -290,6 +315,7 @@
+@@ -305,6 +330,7 @@
                                      <!-- lombok does not add @return or @param which causes warnings, so ignore -->
                                      <doclint>none</doclint>
                                      <sourcepath>${project.build.directory}/delombok</sourcepath>
@@ -618,7 +618,7 @@ index 311db811..d90a79fb 100644
                                  </configuration>
                              </execution>
                          </executions>
-@@ -321,5 +347,88 @@
+@@ -336,5 +362,88 @@
                  </plugins>
              </build>
          </profile>
@@ -708,7 +708,7 @@ index 311db811..d90a79fb 100644
      </profiles>
  </project>
 diff --git a/protocol/pom.xml b/protocol/pom.xml
-index e7a492f6..a783d9b0 100644
+index 6e23170f..c62e0175 100644
 --- a/protocol/pom.xml
 +++ b/protocol/pom.xml
 @@ -4,19 +4,19 @@
@@ -735,9 +735,9 @@ index e7a492f6..a783d9b0 100644
 +    <name>Waterfall-Protocol</name>
 +    <description>Minimal implementation of the Minecraft protocol for use in Waterfall</description>
  
-     <!-- We really shouldn't depend on external repositories, but at least this is the Central staging one -->
-     <repositories>
-@@ -41,8 +41,8 @@
+     <dependencies>
+         <dependency>
+@@ -26,8 +26,8 @@
              <scope>compile</scope>
          </dependency>
          <dependency>

--- a/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch
+++ b/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch
@@ -1,4 +1,4 @@
-From a3f6e1ecf7c446d79590e050cd5360ea6c806af1 Mon Sep 17 00:00:00 2001
+From 79c917d08b19290dd8d9f4a52bec05d95d8b3ecc Mon Sep 17 00:00:00 2001
 From: Daniel Naylor <git@drnaylor.co.uk>
 Date: Tue, 25 Oct 2016 12:23:07 -0400
 Subject: [PATCH] Add support for FML with IP Forwarding enabled
@@ -67,10 +67,10 @@ index 5c74d5f1..d1715b9c 100644
          }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 5713c127..8979ac22 100644
+index bf25658b..9a18e4cc 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -167,8 +167,12 @@ public final class UserConnection implements ProxiedPlayer
+@@ -164,8 +164,12 @@ public final class UserConnection implements ProxiedPlayer
  
          forgeClientHandler = new ForgeClientHandler( this );
  
@@ -100,5 +100,5 @@ index 6dca2048..f5253b89 100644
       * The FML 1.8 handshake token.
       */
 -- 
-2.33.0
+2.34.0
 

--- a/BungeeCord-Patches/0028-Add-timeout-variant-to-connect-methods.patch
+++ b/BungeeCord-Patches/0028-Add-timeout-variant-to-connect-methods.patch
@@ -1,4 +1,4 @@
-From b741851e074a7f9a5233932c3320b6e616bc61ad Mon Sep 17 00:00:00 2001
+From 7b21c06283e4b06fbfd4ad6c50094a3a41233fa7 Mon Sep 17 00:00:00 2001
 From: Ichbinjoe <joe@ibj.io>
 Date: Sat, 16 Jul 2016 20:44:01 -0400
 Subject: [PATCH] Add timeout variant to connect methods
@@ -75,10 +75,10 @@ index e7ab62e5..684eb883 100644
       * Connects / transfers this user to the specified connection, gracefully
       * closing the current one. Depending on the implementation, this method
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index d4348eb7..a8f4378e 100644
+index 94ac3142..68c0f74f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -258,9 +258,20 @@ public final class UserConnection implements ProxiedPlayer
+@@ -255,9 +255,20 @@ public final class UserConnection implements ProxiedPlayer
  
      public void connect(ServerInfo info, final Callback<Boolean> callback, final boolean retry, ServerConnectEvent.Reason reason)
      {
@@ -99,7 +99,7 @@ index d4348eb7..a8f4378e 100644
          if ( callback != null )
          {
              // Convert the Callback<Boolean> to be compatible with Callback<Result> from ServerConnectRequest.
-@@ -354,7 +365,7 @@ public final class UserConnection implements ProxiedPlayer
+@@ -351,7 +362,7 @@ public final class UserConnection implements ProxiedPlayer
                      if ( request.isRetry() && def != null && ( getServer() == null || def != getServer().getInfo() ) )
                      {
                          sendMessage( bungee.getTranslation( "fallback_lobby" ) );
@@ -109,5 +109,5 @@ index d4348eb7..a8f4378e 100644
                      {
                          disconnect( bungee.getTranslation( "fallback_kick", connectionFailMessage( future.cause() ) ) );
 -- 
-2.30.1 (Apple Git-130)
+2.34.0
 

--- a/BungeeCord-Patches/0037-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/BungeeCord-Patches/0037-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -1,15 +1,15 @@
-From 6e9c3003661a15191c022fab3c1949e927d32216 Mon Sep 17 00:00:00 2001
+From e362e1bcdc31386afbc1814972d52997e0717765 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 22 Sep 2017 13:15:09 +0200
 Subject: [PATCH] Allow plugins to use SLF4J for logging
 
 
 diff --git a/api/pom.xml b/api/pom.xml
-index 338864f8..0680a5a5 100644
+index 65ede623..9b29dfca 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -76,5 +76,11 @@
-             <version>1.28</version>
+             <version>1.30-SNAPSHOT</version>
              <scope>compile</scope>
          </dependency>
 +        <!-- Waterfall - Add SLF4J -->
@@ -39,7 +39,7 @@ index 9660234d..3d1e9a3a 100644
       * Called when the plugin has just been loaded. Most of the proxy will not
       * be initialized, so only use it for registering
 diff --git a/log4j/pom.xml b/log4j/pom.xml
-index d5ad0f87..7ec6e530 100644
+index e9678deb..34740637 100644
 --- a/log4j/pom.xml
 +++ b/log4j/pom.xml
 @@ -38,6 +38,12 @@
@@ -56,5 +56,5 @@ index d5ad0f87..7ec6e530 100644
              <groupId>com.lmax</groupId>
              <artifactId>disruptor</artifactId>
 -- 
-2.30.1 (Apple Git-130)
+2.34.0
 

--- a/BungeeCord-Patches/0045-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0045-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From cc0e0d5dba2796f0ab090d54f600c578f93946de Mon Sep 17 00:00:00 2001
+From 90ea2cbbd4de639e9705f149d7d77ee528fc86f6 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -123,10 +123,10 @@ index 5595278b..9e74d158 100644
              if ( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_14 )
              {
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 95dc97b9..fc98b4b1 100644
+index af163836..871a2990 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -768,4 +768,10 @@ public final class UserConnection implements ProxiedPlayer
+@@ -765,4 +765,10 @@ public final class UserConnection implements ProxiedPlayer
      {
          return serverSentScoreboard;
      }
@@ -234,5 +234,5 @@ index 00000000..cb81d1dd
 +// Waterfall end
 \ No newline at end of file
 -- 
-2.33.0
+2.34.0
 


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
21b23624 #3159: Account for the (broken) configuration when ip forward is enabled on bungee but not the server
1ace5c0c Trial snapshot SnakeYAML version