### PR TITLE
Update Java version in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [16,8]
+        java: [17,8]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
As Minecraft 1.18 requires Java 17, I think we should also use Java 17 to build Waterfall.