### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0052-Add-exception-reporting-event.patch
+++ b/BungeeCord-Patches/0052-Add-exception-reporting-event.patch
@@ -1,4 +1,4 @@
-From 21a3747bc5c6ad81d8f3d0b4ea235360767af1e2 Mon Sep 17 00:00:00 2001
+From 47a27d5323e96b3cb1bbcee998d413017eff43b0 Mon Sep 17 00:00:00 2001
 From: theminecoder <theminecoder.dev@gmail.com>
 Date: Wed, 22 Apr 2020 14:00:44 +1000
 Subject: [PATCH] Add exception reporting event
@@ -551,7 +551,7 @@ index 4180c995..90031156 100644
       * Register a {@link Listener} for receiving called events. Methods in this
       * Object which wish to receive events must be annotated with the
 diff --git a/event/src/main/java/net/md_5/bungee/event/EventBus.java b/event/src/main/java/net/md_5/bungee/event/EventBus.java
-index a6d717f2..ac6b9758 100644
+index b3effc8a..adb9f636 100644
 --- a/event/src/main/java/net/md_5/bungee/event/EventBus.java
 +++ b/event/src/main/java/net/md_5/bungee/event/EventBus.java
 @@ -34,7 +34,8 @@ public class EventBus
@@ -564,7 +564,7 @@ index a6d717f2..ac6b9758 100644
      {
          EventHandlerMethod[] handlers = byEventBaked.get( event.getClass() );
  
-@@ -53,7 +54,9 @@ public class EventBus
+@@ -55,7 +56,9 @@ public class EventBus
                      throw new Error( "Method rejected target/argument: " + event, ex );
                  } catch ( InvocationTargetException ex )
                  {
@@ -573,8 +573,8 @@ index a6d717f2..ac6b9758 100644
 +                    logger.log( Level.WARNING, msg, ex.getCause() );
 +                    if( exceptionHandler != null ) exceptionHandler.handleEventException( msg, event, method, ex ); //Waterfall - call passed exception handler
                  }
-             }
-         }
+ 
+                 long elapsed = System.nanoTime() - start;
 diff --git a/event/src/main/java/net/md_5/bungee/event/EventExceptionHandler.java b/event/src/main/java/net/md_5/bungee/event/EventExceptionHandler.java
 new file mode 100644
 index 00000000..088fe9b7
@@ -695,5 +695,5 @@ index 38b75b51..02ec98fc 100644
  
              // If we have a period of 0 or less, only run once
 -- 
-2.30.1 (Apple Git-130)
+2.33.0
 


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
425ee4e1 #3215: Add time measurement per event listener method
42d8300b #3220: Fix server list info being cached permanently