### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0001-POM-Changes.patch
+++ b/BungeeCord-Patches/0001-POM-Changes.patch
@@ -1,4 +1,4 @@
-From 0e67fd377b8bb24b24252fb426beb45938d6b008 Mon Sep 17 00:00:00 2001
+From 69fc7e6667f0ee2d2f30bb049dff9e0ef58f0537 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 19:33:31 +0200
 Subject: [PATCH] POM Changes
@@ -7,7 +7,7 @@ Subject: [PATCH] POM Changes
 - Deploy to papermc mvn repo
 
 diff --git a/api/pom.xml b/api/pom.xml
-index f291fb2e..65ede623 100644
+index 79cab35b..4c87a36e 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -4,42 +4,42 @@
@@ -175,7 +175,7 @@ index 0c244852..0ad5dd16 100644
      <dependencies>
          <dependency>
 diff --git a/config/pom.xml b/config/pom.xml
-index 318ea6ef..2caffc27 100644
+index 87208ac2..7d32ea69 100644
 --- a/config/pom.xml
 +++ b/config/pom.xml
 @@ -4,19 +4,19 @@
@@ -483,7 +483,7 @@ index aa62ce2a..1eff2c93 100644
      <dependencies>
          <dependency>
 diff --git a/pom.xml b/pom.xml
-index c638ef32..a9070b46 100644
+index 1b1e8e9d..f371e3dd 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,18 +3,25 @@
@@ -579,8 +579,8 @@ index c638ef32..a9070b46 100644
 +        </snapshotRepository>
      </distributionManagement>
  
-     <!-- We really shouldn't depend on external repositories, but at least this is the Central staging one -->
-@@ -139,12 +154,21 @@
+     <properties>
+@@ -124,12 +139,21 @@
                      </execution>
                  </executions>
              </plugin>
@@ -602,7 +602,7 @@ index c638ef32..a9070b46 100644
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-checkstyle-plugin</artifactId>
                  <version>3.1.2</version>
-@@ -169,6 +193,7 @@
+@@ -154,6 +178,7 @@
                      </dependency>
                  </dependencies>
              </plugin>
@@ -610,7 +610,7 @@ index c638ef32..a9070b46 100644
              <plugin>
                  <groupId>org.codehaus.mojo</groupId>
                  <artifactId>animal-sniffer-maven-plugin</artifactId>
-@@ -305,6 +330,7 @@
+@@ -290,6 +315,7 @@
                                      <!-- lombok does not add @return or @param which causes warnings, so ignore -->
                                      <doclint>none</doclint>
                                      <sourcepath>${project.build.directory}/delombok</sourcepath>
@@ -618,7 +618,7 @@ index c638ef32..a9070b46 100644
                                  </configuration>
                              </execution>
                          </executions>
-@@ -336,5 +362,88 @@
+@@ -321,5 +347,88 @@
                  </plugins>
              </build>
          </profile>
@@ -708,7 +708,7 @@ index c638ef32..a9070b46 100644
      </profiles>
  </project>
 diff --git a/protocol/pom.xml b/protocol/pom.xml
-index 6e23170f..c62e0175 100644
+index e7a492f6..a783d9b0 100644
 --- a/protocol/pom.xml
 +++ b/protocol/pom.xml
 @@ -4,19 +4,19 @@
@@ -735,9 +735,9 @@ index 6e23170f..c62e0175 100644
 +    <name>Waterfall-Protocol</name>
 +    <description>Minimal implementation of the Minecraft protocol for use in Waterfall</description>
  
-     <dependencies>
-         <dependency>
-@@ -26,8 +26,8 @@
+     <!-- We really shouldn't depend on external repositories, but at least this is the Central staging one -->
+     <repositories>
+@@ -41,8 +41,8 @@
              <scope>compile</scope>
          </dependency>
          <dependency>
@@ -749,7 +749,7 @@ index 6e23170f..c62e0175 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index 84ace403..0ab796b1 100644
+index b49b4c5c..ef7fca2c 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
 @@ -4,18 +4,18 @@
@@ -861,5 +861,5 @@ index 9e0c4539..081bff62 100644
              <scope>compile</scope>
          </dependency>
 -- 
-2.34.0
+2.33.0
 

--- a/BungeeCord-Patches/0035-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
+++ b/BungeeCord-Patches/0035-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
@@ -1,4 +1,4 @@
-From 4c235b1c7e2114a1b3efce3facba152d9f199a1c Mon Sep 17 00:00:00 2001
+From b0958a14cf456ede7b7278e4af7237bd251a6998 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 22 Sep 2017 12:46:47 +0200
 Subject: [PATCH] Use Log4j2 for logging and TerminalConsoleAppender for
@@ -233,7 +233,7 @@ index 00000000..93ce3b14
 +    </Loggers>
 +</Configuration>
 diff --git a/pom.xml b/pom.xml
-index a9070b46..94fad2cc 100644
+index f371e3dd..505d1d14 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -56,11 +56,12 @@
@@ -251,7 +251,7 @@ index a9070b46..94fad2cc 100644
      </modules>
  
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index 7a14b969..22c4f71b 100644
+index 6fd55644..cca0ef95 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
 @@ -71,7 +71,7 @@
@@ -279,7 +279,7 @@ index 7a14b969..22c4f71b 100644
              <groupId>net.sf.jopt-simple</groupId>
              <artifactId>jopt-simple</artifactId>
 @@ -130,6 +131,25 @@
-             <version>1.7.0</version>
+             <version>1.7.2</version>
              <scope>runtime</scope>
          </dependency>
 +        <!-- Waterfall start - Console improvements - bring back slf4j-->
@@ -523,7 +523,7 @@ index 7e465924..00000000
 -</project-shared-configuration>
 diff --git a/slf4j/pom.xml b/slf4j/pom.xml
 deleted file mode 100644
-index d9495ea7..00000000
+index 293597b6..00000000
 --- a/slf4j/pom.xml
 +++ /dev/null
 @@ -1,35 +0,0 @@
@@ -557,17 +557,17 @@ index d9495ea7..00000000
 -        <dependency>
 -            <groupId>org.slf4j</groupId>
 -            <artifactId>slf4j-api</artifactId>
--            <version>1.7.30</version>
+-            <version>1.7.32</version>
 -            <scope>compile</scope>
 -        </dependency>
 -    </dependencies>
 -</project>
 diff --git a/slf4j/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java b/slf4j/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java
 deleted file mode 100644
-index 7cfafc88..00000000
+index 49589454..00000000
 --- a/slf4j/src/main/java/org/slf4j/impl/JDK14LoggerAdapter.java
 +++ /dev/null
-@@ -1,694 +0,0 @@
+@@ -1,700 +0,0 @@
 -/**
 - * Copyright (c) 2004-2011 QOS.ch
 - * All rights reserved.
@@ -1155,6 +1155,8 @@ index 7cfafc88..00000000
 -    static String SELF = JDK14LoggerAdapter.class.getName();
 -    static String SUPER = MarkerIgnoringBase.class.getName();
 -
+-    private static final boolean FILL_CALLER_DATA = Boolean.getBoolean( "net.md_5.bungee.slf4j-caller-data" );
+-
 -    /**
 -     * Fill in caller data if possible.
 -     * 
@@ -1162,6 +1164,10 @@ index 7cfafc88..00000000
 -     *          The record to update
 -     */
 -    final private void fillCallerData(String callerFQCN, LogRecord record) {
+-        if ( !FILL_CALLER_DATA )
+-        {
+-            return;
+-        }
 -        StackTraceElement[] steArray = new Throwable().getStackTrace();
 -
 -        int selfIndex = -1;
@@ -1585,5 +1591,5 @@ index 21a48df6..00000000
 -
 -}
 -- 
-2.34.1.windows.1
+2.33.0
 

--- a/BungeeCord-Patches/0037-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/BungeeCord-Patches/0037-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -1,15 +1,15 @@
-From e362e1bcdc31386afbc1814972d52997e0717765 Mon Sep 17 00:00:00 2001
+From f2b26a8fb95ca8e8cd68638c0c26883f5af6af48 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 22 Sep 2017 13:15:09 +0200
 Subject: [PATCH] Allow plugins to use SLF4J for logging
 
 
 diff --git a/api/pom.xml b/api/pom.xml
-index 65ede623..9b29dfca 100644
+index 4c87a36e..379b6023 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -76,5 +76,11 @@
-             <version>1.30-SNAPSHOT</version>
+             <version>1.30</version>
              <scope>compile</scope>
          </dependency>
 +        <!-- Waterfall - Add SLF4J -->
@@ -39,7 +39,7 @@ index 9660234d..3d1e9a3a 100644
       * Called when the plugin has just been loaded. Most of the proxy will not
       * be initialized, so only use it for registering
 diff --git a/log4j/pom.xml b/log4j/pom.xml
-index e9678deb..34740637 100644
+index f2623ebe..39e2fa42 100644
 --- a/log4j/pom.xml
 +++ b/log4j/pom.xml
 @@ -38,6 +38,12 @@
@@ -56,5 +56,5 @@ index e9678deb..34740637 100644
              <groupId>com.lmax</groupId>
              <artifactId>disruptor</artifactId>
 -- 
-2.34.0
+2.33.0
 

--- a/BungeeCord-Patches/0057-Additional-DoS-mitigations.patch
+++ b/BungeeCord-Patches/0057-Additional-DoS-mitigations.patch
@@ -1,4 +1,4 @@
-From 56a334d52b88a16b48046f8a4fcc8d69bb17387d Mon Sep 17 00:00:00 2001
+From a97fd919809d2284cdc6a5d68168c99bfe795d9c Mon Sep 17 00:00:00 2001
 From: "Five (Xer)" <admin@fivepb.me>
 Date: Sat, 30 Jan 2021 18:04:14 +0100
 Subject: [PATCH] Additional DoS mitigations
@@ -50,7 +50,7 @@ index 40281aa4..a310844d 100644
 +    // Waterfall end
  }
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index 37d28c01..01d35f41 100644
+index f5e414c1..ac83e325 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 @@ -3,7 +3,7 @@ package net.md_5.bungee.protocol;
@@ -76,7 +76,7 @@ index 37d28c01..01d35f41 100644
 +                        throw PACKET_NOT_READ_TO_END;
 +                    }
 +                    // Waterfall end
-                     throw new BadPacketException( "Did not read all bytes from packet " + packet.getClass() + " " + packetId + " Protocol " + protocol + " Direction " + prot.getDirection() );
+                     throw new BadPacketException( "Packet " + protocol + ":" + prot.getDirection() + "/" + packetId + " (" + packet.getClass().getSimpleName() + ") larger than expected, extra bytes: " + in.readableBytes() );
                  }
              } else
 @@ -70,6 +76,11 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
@@ -241,5 +241,5 @@ index 738f0c92..ec33d337 100644
 +    // Waterfall end
  }
 -- 
-2.30.1 (Apple Git-130)
+2.34.1
 


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
b4ccdaa5 #2715: Improve BadPacketException message in MinecraftDecoder
3a116569 #3116: Do not fill in LogRecord caller data by default in slf4j wrapper
2479fab6 #3221: Use computeIfAbsent method in EventBus
51eb1ac6 Dependency upgrades
879f37f0 Upgrade to SnakeYAML 1.30 release