### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
+++ b/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
@@ -1,12 +1,19 @@
-From d92a53555ebe6363d56184c39d60d263f519b3ed Mon Sep 17 00:00:00 2001
+From 7221b508d3c28eabee2cbcf6f6f02aa0a7dca43c Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 3 May 2016 20:31:52 -0700
 Subject: [PATCH] Don't access a ByteBuf's underlying array
 
 It returns the underlying array storage, and does *not* return a view of the buffer as an array
 
+diff --git a/native/mbedtls b/native/mbedtls
+index 8df2f8e7..e483a77c 160000
+--- a/native/mbedtls
++++ b/native/mbedtls
+@@ -1 +1 @@
+-Subproject commit 8df2f8e7b9c7bb9390ac74bb7bace27edca81a2b
++Subproject commit e483a77c85e1f9c1dd2eb1c5a8f552d2617fe400
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
-index 6f9fc6c3..4f3a8c72 100644
+index 70b292f0..91f71c09 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/packet/PluginMessage.java
 @@ -3,6 +3,7 @@ package net.md_5.bungee.protocol.packet;
@@ -69,22 +76,18 @@ index 257779bf..c0cd8570 100644
              // changes in the packet are ignored so we need to send it manually
              con.unsafe().sendPacket( pluginMessage );
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index 1533eadc..a715ec8a 100644
+index 56563346..61165e43 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-@@ -49,9 +49,9 @@ import net.md_5.bungee.protocol.Varint21LengthFieldPrepender;
+@@ -47,7 +47,7 @@ import net.md_5.bungee.protocol.Varint21LengthFieldPrepender;
  public class PipelineUtils
  {
  
 -    public static final AttributeKey<ListenerInfo> LISTENER = AttributeKey.valueOf( "ListerInfo" );
--    public static final AttributeKey<UserConnection> USER = AttributeKey.valueOf( "User" );
--    public static final AttributeKey<BungeeServerInfo> TARGET = AttributeKey.valueOf( "Target" );
-+    public static final AttributeKey<ListenerInfo> LISTENER = AttributeKey.newInstance("ListerInfo");
-+    public static final AttributeKey<UserConnection> USER = AttributeKey.newInstance("User");
-+    public static final AttributeKey<BungeeServerInfo> TARGET = AttributeKey.newInstance("Target");
++    public static final AttributeKey<ListenerInfo> LISTENER = AttributeKey.newInstance( "ListerInfo" );
      public static final ChannelInitializer<Channel> SERVER_CHILD = new ChannelInitializer<Channel>()
      {
          @Override
 -- 
-2.35.1
+2.32.0 (Apple Git-132)
 

--- a/BungeeCord-Patches/0014-Enable-TCP_NODELAY.patch
+++ b/BungeeCord-Patches/0014-Enable-TCP_NODELAY.patch
@@ -1,4 +1,4 @@
-From 836f3e6c00be5148e946b11ed2fa9eb7e2bb1483 Mon Sep 17 00:00:00 2001
+From 9a4d153e6af0749088ef8668c8293d5b469cb020 Mon Sep 17 00:00:00 2001
 From: Harry <me@harry5573.uk>
 Date: Sun, 24 Jan 2016 15:13:29 -0700
 Subject: [PATCH] Enable TCP_NODELAY.
@@ -6,10 +6,10 @@ Subject: [PATCH] Enable TCP_NODELAY.
 This is enabled by default on CraftBukkit/Spigot >= 1.8 and may help with network performance.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index a715ec8a..abc60316 100644
+index 61165e43..2d373660 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-@@ -169,6 +169,7 @@ public class PipelineUtils
+@@ -165,6 +165,7 @@ public class PipelineUtils
              {
                  // IP_TOS is not supported (Windows XP / Windows Server 2003)
              }
@@ -18,5 +18,5 @@ index a715ec8a..abc60316 100644
              ch.config().setWriteBufferWaterMark( MARK );
  
 -- 
-2.30.1 (Apple Git-130)
+2.32.0 (Apple Git-132)
 

--- a/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From ccd9cbc89900f06d54463678d3647587ec34b112 Mon Sep 17 00:00:00 2001
+From b0b475097ab0749bce066f1d1d967318f42de5f7 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -37,7 +37,7 @@ index 773e954c..57bd22b7 100644
              {
                  packet.read( in, prot.getDirection(), protocolVersion );
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-index 9c8a7118..220365dd 100644
+index 21f4a5d5..220365dd 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 @@ -522,14 +522,23 @@ public enum Protocol
@@ -60,7 +60,7 @@ index 9c8a7118..220365dd 100644
              {
                  throw new BadPacketException( "Unsupported protocol version " + version );
              }
--            if ( id > MAX_PACKET_ID )
+-            if ( id > MAX_PACKET_ID || id < 0 )
 +            if ( !hasPacket(id, supportsForge) )
              {
                  throw new BadPacketException( "Packet with id " + id + " outside of range" );
@@ -122,5 +122,5 @@ index 75164c67..f87ce538 100644
          {
              rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
 -- 
-2.35.1
+2.32.0 (Apple Git-132)
 

--- a/BungeeCord-Patches/0051-ConnectionInitEvent.patch
+++ b/BungeeCord-Patches/0051-ConnectionInitEvent.patch
@@ -1,4 +1,4 @@
-From f356c6e79ebca197af27f7dacda9410dea3117d1 Mon Sep 17 00:00:00 2001
+From 8f597104fbf7db67b2f09731b116be384bb5089d Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 2 Dec 2019 11:35:17 +0000
 Subject: [PATCH] ConnectionInitEvent
@@ -67,7 +67,7 @@ index 00000000..6e79675f
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index abc60316..96704d5e 100644
+index 2d373660..2a21243b 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 @@ -1,6 +1,7 @@
@@ -78,7 +78,7 @@ index abc60316..96704d5e 100644
  import io.netty.buffer.PooledByteBufAllocator;
  import io.netty.channel.Channel;
  import io.netty.channel.ChannelException;
-@@ -64,7 +65,6 @@ public class PipelineUtils
+@@ -60,7 +61,6 @@ public class PipelineUtils
                  ch.close();
                  return;
              }
@@ -86,7 +86,7 @@ index abc60316..96704d5e 100644
              ListenerInfo listener = ch.attr( LISTENER ).get();
  
              if ( BungeeCord.getInstance().getPluginManager().callEvent( new ClientConnectEvent( remoteAddress, listener ) ).isCancelled() )
-@@ -73,7 +73,21 @@ public class PipelineUtils
+@@ -69,7 +69,21 @@ public class PipelineUtils
                  return;
              }
  
@@ -108,7 +108,7 @@ index abc60316..96704d5e 100644
              ch.pipeline().addBefore( FRAME_DECODER, LEGACY_DECODER, new LegacyDecoder() );
              ch.pipeline().addAfter( FRAME_DECODER, PACKET_DECODER, new MinecraftDecoder( Protocol.HANDSHAKE, true, ProxyServer.getInstance().getProtocolVersion() ) );
              ch.pipeline().addAfter( FRAME_PREPENDER, PACKET_ENCODER, new MinecraftEncoder( Protocol.HANDSHAKE, true, ProxyServer.getInstance().getProtocolVersion() ) );
-@@ -84,6 +98,9 @@ public class PipelineUtils
+@@ -80,6 +94,9 @@ public class PipelineUtils
              {
                  ch.pipeline().addFirst( new HAProxyMessageDecoder() );
              }
@@ -119,5 +119,5 @@ index abc60316..96704d5e 100644
      };
      public static final Base BASE = new Base();
 -- 
-2.30.1 (Apple Git-130)
+2.32.0 (Apple Git-132)
 


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
34d416a4 #3261: Remove unused AttributeKeys
410f64bc #3268: Correct plugin message size check
978e68fc #3265: Print all thrown exception
a17d8f8a #3264: Negative packet ids are also outside of range
