### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0001-POM-Changes.patch
+++ b/BungeeCord-Patches/0001-POM-Changes.patch
@@ -1,4 +1,4 @@
-From 0bab19d41f1f1062e6d8232d05255e0e16ce355a Mon Sep 17 00:00:00 2001
+From 07b7cda5c28940d220005566366a47e6840de591 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 19:33:31 +0200
 Subject: [PATCH] POM Changes
@@ -7,7 +7,7 @@ Subject: [PATCH] POM Changes
 - Deploy to papermc mvn repo
 
 diff --git a/api/pom.xml b/api/pom.xml
-index 6b08df37..163fc93b 100644
+index 67e0673d..83ae2220 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -4,42 +4,42 @@
@@ -18,7 +18,7 @@ index 6b08df37..163fc93b 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -26,7 +26,7 @@ index 6b08df37..163fc93b 100644
 -    <artifactId>bungeecord-api</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-api</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-API</name>
@@ -67,7 +67,7 @@ index 6b08df37..163fc93b 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/bootstrap/pom.xml b/bootstrap/pom.xml
-index 6a3258f4..5ec5faf7 100644
+index 59b07868..e5797d70 100644
 --- a/bootstrap/pom.xml
 +++ b/bootstrap/pom.xml
 @@ -4,39 +4,40 @@
@@ -78,7 +78,7 @@ index 6a3258f4..5ec5faf7 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -86,7 +86,7 @@ index 6a3258f4..5ec5faf7 100644
 -    <artifactId>bungeecord-bootstrap</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-bootstrap</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Bootstrap</name>
@@ -145,7 +145,7 @@ index 6be22739..a4516ed9 100644
              return;
          }
 diff --git a/chat/pom.xml b/chat/pom.xml
-index f695c462..003b3f6c 100644
+index c9b91050..040aa0f7 100644
 --- a/chat/pom.xml
 +++ b/chat/pom.xml
 @@ -4,19 +4,19 @@
@@ -156,7 +156,7 @@ index f695c462..003b3f6c 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -164,7 +164,7 @@ index f695c462..003b3f6c 100644
 -    <artifactId>bungeecord-chat</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-chat</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Chat</name>
@@ -175,7 +175,7 @@ index f695c462..003b3f6c 100644
      <dependencies>
          <dependency>
 diff --git a/config/pom.xml b/config/pom.xml
-index 807223ec..91da386a 100644
+index 799ce536..7e2d07a7 100644
 --- a/config/pom.xml
 +++ b/config/pom.xml
 @@ -4,19 +4,19 @@
@@ -186,7 +186,7 @@ index 807223ec..91da386a 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -194,7 +194,7 @@ index 807223ec..91da386a 100644
 -    <artifactId>bungeecord-config</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-config</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Config</name>
@@ -205,7 +205,7 @@ index 807223ec..91da386a 100644
      <dependencies>
          <dependency>
 diff --git a/event/pom.xml b/event/pom.xml
-index 46c38144..ac85fc82 100644
+index 30842b97..b2541c62 100644
 --- a/event/pom.xml
 +++ b/event/pom.xml
 @@ -4,17 +4,17 @@
@@ -216,7 +216,7 @@ index 46c38144..ac85fc82 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -224,7 +224,7 @@ index 46c38144..ac85fc82 100644
 -    <artifactId>bungeecord-event</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-event</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Event</name>
@@ -233,7 +233,7 @@ index 46c38144..ac85fc82 100644
 +    <description>Generic java event dispatching API intended for use with Waterfall.</description>
  </project>
 diff --git a/log/pom.xml b/log/pom.xml
-index 8bba9f62..d61dba6f 100644
+index fd0bee2c..8368f7b3 100644
 --- a/log/pom.xml
 +++ b/log/pom.xml
 @@ -4,19 +4,19 @@
@@ -244,7 +244,7 @@ index 8bba9f62..d61dba6f 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -252,7 +252,7 @@ index 8bba9f62..d61dba6f 100644
 -    <artifactId>bungeecord-log</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-log</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Log</name>
@@ -274,7 +274,7 @@ index 8bba9f62..d61dba6f 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/module/cmd-alert/pom.xml b/module/cmd-alert/pom.xml
-index 88b4aa99..64d197ce 100644
+index f9d39d6f..47d83c68 100644
 --- a/module/cmd-alert/pom.xml
 +++ b/module/cmd-alert/pom.xml
 @@ -4,14 +4,14 @@
@@ -285,7 +285,7 @@ index 88b4aa99..64d197ce 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -293,11 +293,11 @@ index 88b4aa99..64d197ce 100644
 -    <artifactId>bungeecord-module-cmd-alert</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-alert</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-find/pom.xml b/module/cmd-find/pom.xml
-index cb15b266..c4ad20de 100644
+index 4eb9508f..6db051a8 100644
 --- a/module/cmd-find/pom.xml
 +++ b/module/cmd-find/pom.xml
 @@ -4,14 +4,14 @@
@@ -308,7 +308,7 @@ index cb15b266..c4ad20de 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -316,11 +316,11 @@ index cb15b266..c4ad20de 100644
 -    <artifactId>bungeecord-module-cmd-find</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-find</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-kick/pom.xml b/module/cmd-kick/pom.xml
-index a43919ef..17d3dc71 100644
+index 3f735c39..e23f59d2 100644
 --- a/module/cmd-kick/pom.xml
 +++ b/module/cmd-kick/pom.xml
 @@ -4,14 +4,14 @@
@@ -331,7 +331,7 @@ index a43919ef..17d3dc71 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -339,11 +339,11 @@ index a43919ef..17d3dc71 100644
 -    <artifactId>bungeecord-module-cmd-kick</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-kick</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-list/pom.xml b/module/cmd-list/pom.xml
-index 81a660bf..9e22202d 100644
+index 6b503c52..88ebf0f7 100644
 --- a/module/cmd-list/pom.xml
 +++ b/module/cmd-list/pom.xml
 @@ -4,14 +4,14 @@
@@ -354,7 +354,7 @@ index 81a660bf..9e22202d 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -362,11 +362,11 @@ index 81a660bf..9e22202d 100644
 -    <artifactId>bungeecord-module-cmd-list</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-list</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-send/pom.xml b/module/cmd-send/pom.xml
-index 574b6af3..5326f925 100644
+index 07cef355..5887d1e9 100644
 --- a/module/cmd-send/pom.xml
 +++ b/module/cmd-send/pom.xml
 @@ -4,14 +4,14 @@
@@ -377,7 +377,7 @@ index 574b6af3..5326f925 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -385,11 +385,11 @@ index 574b6af3..5326f925 100644
 -    <artifactId>bungeecord-module-cmd-send</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-send</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-server/pom.xml b/module/cmd-server/pom.xml
-index f9de38c4..86faab24 100644
+index 03165b52..91a09d8b 100644
 --- a/module/cmd-server/pom.xml
 +++ b/module/cmd-server/pom.xml
 @@ -4,14 +4,14 @@
@@ -400,7 +400,7 @@ index f9de38c4..86faab24 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -408,11 +408,11 @@ index f9de38c4..86faab24 100644
 -    <artifactId>bungeecord-module-cmd-server</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-server</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/pom.xml b/module/pom.xml
-index 961560dc..0de7979e 100644
+index 0b495660..89c34e80 100644
 --- a/module/pom.xml
 +++ b/module/pom.xml
 @@ -4,19 +4,19 @@
@@ -423,7 +423,7 @@ index 961560dc..0de7979e 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -431,7 +431,7 @@ index 961560dc..0de7979e 100644
 -    <artifactId>bungeecord-module</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>pom</packaging>
  
 -    <name>BungeeCord Modules</name>
@@ -461,7 +461,7 @@ index 961560dc..0de7979e 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/module/reconnect-yaml/pom.xml b/module/reconnect-yaml/pom.xml
-index 4f3332dd..8aff53bd 100644
+index 718f47a7..3ba983d9 100644
 --- a/module/reconnect-yaml/pom.xml
 +++ b/module/reconnect-yaml/pom.xml
 @@ -4,8 +4,8 @@
@@ -472,11 +472,11 @@ index 4f3332dd..8aff53bd 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
 diff --git a/native/pom.xml b/native/pom.xml
-index c7478c96..e137dfcc 100644
+index effa68e6..2412768b 100644
 --- a/native/pom.xml
 +++ b/native/pom.xml
 @@ -4,19 +4,19 @@
@@ -487,7 +487,7 @@ index c7478c96..e137dfcc 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -495,7 +495,7 @@ index c7478c96..e137dfcc 100644
 -    <artifactId>bungeecord-native</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-native</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Native</name>
@@ -506,7 +506,7 @@ index c7478c96..e137dfcc 100644
      <dependencies>
          <dependency>
 diff --git a/pom.xml b/pom.xml
-index c118aa69..432fd5c5 100644
+index acdf957a..ef36fe95 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,18 +3,25 @@
@@ -524,7 +524,7 @@ index c118aa69..432fd5c5 100644
 +
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-parent</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>pom</packaging>
  
 -    <name>BungeeCord-Parent</name>
@@ -731,7 +731,7 @@ index c118aa69..432fd5c5 100644
      </profiles>
  </project>
 diff --git a/protocol/pom.xml b/protocol/pom.xml
-index bb2b14fc..221469b9 100644
+index d8ce7f6c..c6105b87 100644
 --- a/protocol/pom.xml
 +++ b/protocol/pom.xml
 @@ -4,19 +4,19 @@
@@ -742,7 +742,7 @@ index bb2b14fc..221469b9 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -750,7 +750,7 @@ index bb2b14fc..221469b9 100644
 -    <artifactId>bungeecord-protocol</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-protocol</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Protocol</name>
@@ -772,7 +772,7 @@ index bb2b14fc..221469b9 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index f11a4fb7..f2a97611 100644
+index a783a605..39bff865 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
 @@ -4,18 +4,18 @@
@@ -783,7 +783,7 @@ index f11a4fb7..f2a97611 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -791,7 +791,7 @@ index f11a4fb7..f2a97611 100644
 -    <artifactId>bungeecord-proxy</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-proxy</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Proxy</name>
@@ -843,7 +843,7 @@ index f11a4fb7..f2a97611 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/query/pom.xml b/query/pom.xml
-index 90a4c8d5..81af5457 100644
+index 7688b844..fc864f83 100644
 --- a/query/pom.xml
 +++ b/query/pom.xml
 @@ -4,19 +4,19 @@
@@ -854,7 +854,7 @@ index 90a4c8d5..81af5457 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.19-R0.1-SNAPSHOT</version>
+         <version>1.20-R0.1-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -862,7 +862,7 @@ index 90a4c8d5..81af5457 100644
 -    <artifactId>bungeecord-query</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-query</artifactId>
-     <version>1.19-R0.1-SNAPSHOT</version>
+     <version>1.20-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Query</name>
@@ -884,5 +884,5 @@ index 90a4c8d5..81af5457 100644
              <scope>compile</scope>
          </dependency>
 -- 
-2.40.1.windows.1
+2.41.0.windows.1
 

--- a/BungeeCord-Patches/0007-Fixup-ProtocolConstants.patch
+++ b/BungeeCord-Patches/0007-Fixup-ProtocolConstants.patch
@@ -1,14 +1,14 @@
-From af42b160de5d603752c202a28ff8328bad2036a6 Mon Sep 17 00:00:00 2001
+From 93d49833d2e9eecf92515baee0605f412352f57e Mon Sep 17 00:00:00 2001
 From: Troy Frew <fuzzy_bot@arenaga.me>
 Date: Tue, 15 Nov 2016 09:07:51 -0500
 Subject: [PATCH] Fixup ProtocolConstants
 
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
-index 580445d7..fa625d96 100644
+index 8b27abff..18574b30 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
-@@ -109,6 +109,16 @@ public class ProtocolConstants
+@@ -112,6 +112,16 @@ public class ProtocolConstants
          SUPPORTED_VERSION_IDS = supportedVersionIds.build();
      }
  
@@ -26,5 +26,5 @@ index 580445d7..fa625d96 100644
      {
  
 -- 
-2.37.3.windows.1
+2.41.0.windows.1
 

--- a/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
+++ b/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
@@ -1,4 +1,4 @@
-From aa69ee55cd4bb1acb430cb17153c6e1bd6f0fe40 Mon Sep 17 00:00:00 2001
+From 55c22f21707d2e9e81d2691c12f3a990b0c28c3d Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 3 May 2016 20:31:52 -0700
 Subject: [PATCH] Don't access a ByteBuf's underlying array
@@ -43,10 +43,10 @@ index 70b292f0..91f71c09 100644
       * Allow this packet to be sent as an "extended" packet.
       */
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 3be014b2..e00c5659 100644
+index 3f01fb24..0afa455f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -249,7 +249,7 @@ public class ServerConnector extends PacketHandler
+@@ -251,7 +251,7 @@ public class ServerConnector extends PacketHandler
              {
                  ByteBuf brand = ByteBufAllocator.DEFAULT.heapBuffer();
                  DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")", brand );
@@ -82,5 +82,5 @@ index 5b9c35d1..2d6885a9 100644
      {
          @Override
 -- 
-2.40.0
+2.41.0.windows.1
 

--- a/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From 8056d2b9940e8bcf664c633e97f1a4068308dfe3 Mon Sep 17 00:00:00 2001
+From 66fcaee1c689ff5f8b4f016a31f17c9d8650cb46 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -66,7 +66,7 @@ index 746defae..dabfa4db 100644
                  throw new BadPacketException( "Packet with id " + id + " outside of range" );
              }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 1255298c..aa721cdc 100644
+index 9bceb122..66f0d0a2 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -34,7 +34,9 @@ import net.md_5.bungee.forge.ForgeUtils;
@@ -93,7 +93,7 @@ index 1255298c..aa721cdc 100644
  
          ch.write( BungeeCord.getInstance().registerChannels( user.getPendingConnection().getVersion() ) );
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index d642e68d..bac51311 100644
+index 09b9f342..4b530a8b 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 @@ -73,6 +73,7 @@ public final class UserConnection implements ProxiedPlayer
@@ -105,10 +105,10 @@ index d642e68d..bac51311 100644
      @Getter
      @NonNull
 diff --git a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-index 81146df6..5ecca5a0 100644
+index 5440f4b5..4dde5cff 100644
 --- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 +++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-@@ -335,6 +335,12 @@ public abstract class EntityMap
+@@ -336,6 +336,12 @@ public abstract class EntityMap
          int packetId = DefinedPacket.readVarInt( packet );
          int packetIdLength = packet.readerIndex() - readerIndex;
  
@@ -122,5 +122,5 @@ index 81146df6..5ecca5a0 100644
          {
              rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
 -- 
-2.37.3.windows.1
+2.41.0.windows.1
 

--- a/BungeeCord-Patches/0019-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0019-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From 42c5c1b496b0fbd6b078f6df5ab94fed4455bb52 Mon Sep 17 00:00:00 2001
+From 023d412da1f2d78c1e8f60fbaf92abf5a91016ff Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -7,10 +7,10 @@ This functionality of this patch was adopted upstream, however, this
 patch remains for a few misc improvements around here
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index aa721cdc..981b0200 100644
+index 66f0d0a2..9f36f606 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -460,6 +460,6 @@ public class ServerConnector extends PacketHandler
+@@ -464,6 +464,6 @@ public class ServerConnector extends PacketHandler
      @Override
      public String toString()
      {
@@ -31,7 +31,7 @@ index b3fe9a64..f84554dd 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 59e74208..115e95a4 100644
+index bd8a467d..b8450c28 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 @@ -719,20 +719,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
@@ -69,5 +69,5 @@ index e87cd53a..c30093d7 100644
      }
  }
 -- 
-2.37.3.windows.1
+2.41.0.windows.1
 

--- a/BungeeCord-Patches/0026-Improve-ServerKickEvent.patch
+++ b/BungeeCord-Patches/0026-Improve-ServerKickEvent.patch
@@ -1,4 +1,4 @@
-From 4ac61dbb433da47f6a5992822fe15e03d9e72a58 Mon Sep 17 00:00:00 2001
+From 19b68d7b84a52a3bb92adb369b609298b37d352a Mon Sep 17 00:00:00 2001
 From: Nathan Poirier <nathan@poirier.io>
 Date: Tue, 28 Jun 2016 23:00:49 -0500
 Subject: [PATCH] Improve ServerKickEvent
@@ -62,10 +62,10 @@ index 0e1ef5c4..ee63732d 100644
      @Deprecated
      public String getKickReason()
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 981b0200..9bd063f5 100644
+index 9f36f606..6473a10c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -377,7 +377,7 @@ public class ServerConnector extends PacketHandler
+@@ -381,7 +381,7 @@ public class ServerConnector extends PacketHandler
      public void handle(Kick kick) throws Exception
      {
          ServerInfo def = user.updateAndGetNextServer( target );
@@ -75,7 +75,7 @@ index 981b0200..9bd063f5 100644
          {
              // Pre cancel the event if we are going to try another server
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 2e436999..c5217561 100644
+index f84554dd..e8ef17a1 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 @@ -90,16 +90,19 @@ public class DownstreamBridge extends PacketHandler
@@ -138,5 +138,5 @@ index 2e436999..c5217561 100644
          {
              con.connectNow( event.getCancelServer(), ServerConnectEvent.Reason.KICK_REDIRECT );
 -- 
-2.38.1
+2.41.0.windows.1
 

--- a/BungeeCord-Patches/0035-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
+++ b/BungeeCord-Patches/0035-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
@@ -1,4 +1,4 @@
-From 43de49256f52a8990a41b6194163023d1e169f3d Mon Sep 17 00:00:00 2001
+From 3ce400468f64409f9c80898d51168354d51f46ca Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 22 Sep 2017 12:46:47 +0200
 Subject: [PATCH] Use Log4j2 for logging and TerminalConsoleAppender for
@@ -6,7 +6,7 @@ Subject: [PATCH] Use Log4j2 for logging and TerminalConsoleAppender for
 
 
 diff --git a/bootstrap/pom.xml b/bootstrap/pom.xml
-index 5ec5faf7..f9ec2c1c 100644
+index e5797d70..8328e576 100644
 --- a/bootstrap/pom.xml
 +++ b/bootstrap/pom.xml
 @@ -49,6 +49,9 @@
@@ -39,7 +39,7 @@ index 5ec5faf7..f9ec2c1c 100644
      </build>
 diff --git a/log4j/pom.xml b/log4j/pom.xml
 new file mode 100644
-index 00000000..9c561bcc
+index 00000000..a7d2aa8f
 --- /dev/null
 +++ b/log4j/pom.xml
 @@ -0,0 +1,48 @@
@@ -50,13 +50,13 @@ index 00000000..9c561bcc
 +    <parent>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-+        <version>1.19-R0.1-SNAPSHOT</version>
++        <version>1.20-R0.1-SNAPSHOT</version>
 +        <relativePath>../pom.xml</relativePath>
 +    </parent>
 +
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-log4j</artifactId>
-+    <version>1.19-R0.1-SNAPSHOT</version>
++    <version>1.20-R0.1-SNAPSHOT</version>
 +    <packaging>jar</packaging>
 +
 +    <name>Waterfall-Log</name>
@@ -233,7 +233,7 @@ index 00000000..cfd039cd
 +    </Loggers>
 +</Configuration>
 diff --git a/pom.xml b/pom.xml
-index 432fd5c5..77991d81 100644
+index ef36fe95..1ab45c9e 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -56,11 +56,12 @@
@@ -251,7 +251,7 @@ index 432fd5c5..77991d81 100644
      </modules>
  
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index e004f988..368df864 100644
+index aa91ee5a..83d8719b 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
 @@ -71,7 +71,7 @@
@@ -559,7 +559,7 @@ index 7e465924..00000000
 -</project-shared-configuration>
 diff --git a/slf4j/pom.xml b/slf4j/pom.xml
 deleted file mode 100644
-index 1716c3cf..00000000
+index 58a25501..00000000
 --- a/slf4j/pom.xml
 +++ /dev/null
 @@ -1,35 +0,0 @@
@@ -571,13 +571,13 @@ index 1716c3cf..00000000
 -    <parent>
 -        <groupId>net.md-5</groupId>
 -        <artifactId>bungeecord-parent</artifactId>
--        <version>1.19-R0.1-SNAPSHOT</version>
+-        <version>1.20-R0.1-SNAPSHOT</version>
 -        <relativePath>../pom.xml</relativePath>
 -    </parent>
 -
 -    <groupId>net.md-5</groupId>
 -    <artifactId>bungeecord-slf4j</artifactId>
--    <version>1.19-R0.1-SNAPSHOT</version>
+-    <version>1.20-R0.1-SNAPSHOT</version>
 -    <packaging>jar</packaging>
 -
 -    <name>BungeeCord-SLF4J</name>
@@ -1627,5 +1627,5 @@ index 21a48df6..00000000
 -
 -}
 -- 
-2.40.1.windows.1
+2.41.0.windows.1
 

--- a/BungeeCord-Patches/0037-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/BungeeCord-Patches/0037-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -1,15 +1,15 @@
-From b773b7b9601c7f191de0849bd58e0758a549d2fc Mon Sep 17 00:00:00 2001
+From 477511185022dd5740bc7c4dbf3f6ab5787ed49e Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 22 Sep 2017 13:15:09 +0200
 Subject: [PATCH] Allow plugins to use SLF4J for logging
 
 
 diff --git a/api/pom.xml b/api/pom.xml
-index 163fc93b..9a01f8c6 100644
+index 83ae2220..01b8f888 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -75,5 +75,11 @@
-             <version>1.33</version>
+             <version>2.0</version>
              <scope>compile</scope>
          </dependency>
 +        <!-- Waterfall - Add SLF4J -->
@@ -39,7 +39,7 @@ index 9660234d..3d1e9a3a 100644
       * Called when the plugin has just been loaded. Most of the proxy will not
       * be initialized, so only use it for registering
 diff --git a/log4j/pom.xml b/log4j/pom.xml
-index 9c561bcc..a01910ee 100644
+index a7d2aa8f..976b8079 100644
 --- a/log4j/pom.xml
 +++ b/log4j/pom.xml
 @@ -38,6 +38,24 @@
@@ -68,5 +68,5 @@ index 9c561bcc..a01910ee 100644
              <groupId>com.lmax</groupId>
              <artifactId>disruptor</artifactId>
 -- 
-2.40.1.windows.1
+2.41.0.windows.1
 

--- a/BungeeCord-Patches/0045-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0045-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From 201c5254e561f61e44afe7854dc6d2a111963cf1 Mon Sep 17 00:00:00 2001
+From acaac51b18fa6e8bc1f2b1dacc77565ff7595648 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -57,7 +57,7 @@ index 4ff8da6d..e860214f 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 9bd063f5..8181d76b 100644
+index 6473a10c..60232e52 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -240,7 +240,7 @@ public class ServerConnector extends PacketHandler
@@ -69,7 +69,7 @@ index 9bd063f5..8181d76b 100644
          {
              ch.write( user.getSettings() );
          }
-@@ -293,6 +293,7 @@ public class ServerConnector extends PacketHandler
+@@ -295,6 +295,7 @@ public class ServerConnector extends PacketHandler
              user.getTabListHandler().onServerChange();
  
              Scoreboard serverScoreboard = user.getServerSentScoreboard();
@@ -77,7 +77,7 @@ index 9bd063f5..8181d76b 100644
              for ( Objective objective : serverScoreboard.getObjectives() )
              {
                  user.unsafe().sendPacket( new ScoreboardObjective( objective.getName(), objective.getValue(), ScoreboardObjective.HealthDisplay.fromString( objective.getType() ), (byte) 1 ) );
-@@ -305,6 +306,7 @@ public class ServerConnector extends PacketHandler
+@@ -307,6 +308,7 @@ public class ServerConnector extends PacketHandler
              {
                  user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.Team( team.getName() ) );
              }
@@ -85,14 +85,15 @@ index 9bd063f5..8181d76b 100644
              serverScoreboard.clear();
  
              for ( UUID bossbar : user.getSentBossBars() )
-@@ -323,13 +325,37 @@ public class ServerConnector extends PacketHandler
+@@ -325,13 +327,33 @@ public class ServerConnector extends PacketHandler
              }
  
              user.setDimensionChange( true );
 -            if ( login.getDimension() == user.getDimension() )
 +            if ( !user.isDisableEntityMetadataRewrite() && login.getDimension() == user.getDimension() ) // Waterfall - defer
              {
-                 user.unsafe().sendPacket( new Respawn( (Integer) login.getDimension() >= 0 ? -1 : 0, login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(), false, login.getDeathLocation() ) );
+                 user.unsafe().sendPacket( new Respawn( (Integer) login.getDimension() >= 0 ? -1 : 0, login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(),
+                         false, login.getDeathLocation(), login.getPortalCooldown() ) );
              }
  
              user.setServerEntityId( login.getEntityId() );
@@ -101,31 +102,26 @@ index 9bd063f5..8181d76b 100644
 +            if ( user.isDisableEntityMetadataRewrite() ) {
 +                // Ensure that we maintain consistency
 +                user.setClientEntityId( login.getEntityId() );
-+
 +                // Only send if we are not in the same dimension
 +                if ( login.getDimension() != user.getDimension() ) // Waterfall - defer
 +                {
-+                    user.unsafe().sendPacket( new Respawn( (Integer) user.getDimension() >= 0 ? -1 : 0, login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(), false, login.getDeathLocation() ) );
++                    user.unsafe().sendPacket( new Respawn( (Integer) user.getDimension() >= 0 ? -1 : 0, login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(), false, login.getDeathLocation(), login.getPortalCooldown() ) );
 +                }
-+
 +                Login modLogin = new Login( login.getEntityId(), login.isHardcore(), login.getGameMode(), login.getPreviousGameMode(), login.getWorldNames(), login.getDimensions(), login.getDimension(), login.getWorldName(), login.getSeed(), login.getDifficulty(),
-+                        (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.getViewDistance(), login.getSimulationDistance(), login.isReducedDebugInfo(), login.isNormalRespawn(), login.isDebug(), login.isFlat(), login.getDeathLocation() );
++                        (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.getViewDistance(), login.getSimulationDistance(), login.isReducedDebugInfo(), login.isNormalRespawn(), login.isDebug(), login.isFlat(), login.getDeathLocation(), login.getPortalCooldown() );
 +                user.unsafe().sendPacket(modLogin);
-+
 +                // Only send if we're in the same dimension
 +                if ( login.getDimension() == user.getDimension() ) // Waterfall - defer
 +                {
-+                    user.unsafe().sendPacket( new Respawn( (Integer) login.getDimension() >= 0 ? -1 : 0, login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(), false, login.getDeathLocation() ) );
++                    user.unsafe().sendPacket( new Respawn( (Integer) login.getDimension() >= 0 ? -1 : 0, login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(), false, login.getDeathLocation(), login.getPortalCooldown() ) );
 +                }
 +            }
 +            // Waterfall end
-             user.unsafe().sendPacket( new Respawn( login.getDimension(), login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(), false, login.getDeathLocation() ) );
-+
+             user.unsafe().sendPacket( new Respawn( login.getDimension(), login.getWorldName(), login.getSeed(), login.getDifficulty(), login.getGameMode(), login.getPreviousGameMode(), login.getLevelType(), login.isDebug(), login.isFlat(),
+                     false, login.getDeathLocation(), login.getPortalCooldown() ) );
              if ( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_14 )
-             {
-                 user.unsafe().sendPacket( new ViewDistance( login.getViewDistance() ) );
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 7fe08ecd..5961392a 100644
+index e0a9d338..35bf4c9f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 @@ -775,4 +775,10 @@ public final class UserConnection implements ProxiedPlayer
@@ -160,7 +156,7 @@ index c7180803..04840037 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-index 5ecca5a0..28d2127f 100644
+index 4dde5cff..65ea8044 100644
 --- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 +++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 @@ -27,6 +27,11 @@ public abstract class EntityMap
@@ -175,7 +171,7 @@ index 5ecca5a0..28d2127f 100644
          switch ( version )
          {
              case ProtocolConstants.MINECRAFT_1_8:
-@@ -297,7 +302,13 @@ public abstract class EntityMap
+@@ -298,7 +303,13 @@ public abstract class EntityMap
                      DefinedPacket.readVarInt( packet );
                      break;
                  default:
@@ -228,5 +224,5 @@ index 00000000..cb81d1dd
 +// Waterfall end
 \ No newline at end of file
 -- 
-2.37.3.windows.1
+2.41.0.windows.1
 


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
68200133 Minecraft 1.20 support