### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0012-Better-unit-tests-for-Chat-API.patch
+++ b/BungeeCord-Patches/0012-Better-unit-tests-for-Chat-API.patch
@@ -1,15 +1,15 @@
-From 070fbdb76af6565d8529655d4648e0efca42106e Mon Sep 17 00:00:00 2001
+From c11014146824ca18446e6175026a088ca23a3369 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 17:36:31 -0600
 Subject: [PATCH] Better unit tests for Chat API
 
 
 diff --git a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
-index 95dd1620..98eb30ab 100644
+index 1273e098..2907630d 100644
 --- a/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
 +++ b/chat/src/test/java/net/md_5/bungee/api/chat/ComponentsTest.java
 @@ -666,6 +666,26 @@ public class ComponentsTest
-         Assert.assertEquals( testClickEvent, extraGetter.apply( eventRetention, 1 ).getClickEvent() );
+         assertEquals( testClickEvent, extraGetter.apply( eventRetention, 1 ).getClickEvent() );
      }
  
 +    @Test
@@ -19,39 +19,39 @@ index 95dd1620..98eb30ab 100644
 +                .bold(true).underlined(true).italic(true).strikethrough(true).obfuscated(true)
 +                .append("World").underlined(false).strikethrough(false).create();
 +
-+        Assert.assertTrue( components[0].isBold() );
-+        Assert.assertTrue( components[0].isUnderlined() );
-+        Assert.assertTrue( components[0].isItalic() );
-+        Assert.assertTrue( components[0].isStrikethrough() );
-+        Assert.assertTrue( components[0].isObfuscated() );
++        assertTrue( components[0].isBold() );
++        assertTrue( components[0].isUnderlined() );
++        assertTrue( components[0].isItalic() );
++        assertTrue( components[0].isStrikethrough() );
++        assertTrue( components[0].isObfuscated() );
 +
-+        Assert.assertTrue( components[1].isBold() );
-+        Assert.assertFalse( components[1].isUnderlined() );
-+        Assert.assertTrue( components[1].isItalic() );
-+        Assert.assertFalse( components[1].isStrikethrough() );
-+        Assert.assertTrue( components[1].isObfuscated() );
++        assertTrue( components[1].isBold() );
++        assertFalse( components[1].isUnderlined() );
++        assertTrue( components[1].isItalic() );
++        assertFalse( components[1].isStrikethrough() );
++        assertTrue( components[1].isObfuscated() );
 +    }
 +
-     @Test(expected = IllegalArgumentException.class)
+     @Test
      public void testLoopSimple()
      {
 diff --git a/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java b/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
-index 9e37eed0..a25a01b8 100644
+index 9ec5dcb1..e56c8353 100644
 --- a/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
 +++ b/chat/src/test/java/net/md_5/bungee/api/chat/TranslatableComponentTest.java
 @@ -25,4 +25,12 @@ public class TranslatableComponentTest
-         Assert.assertEquals( "Test string with a placeholder", TextComponent.toPlainText( baseComponents ) );
-         Assert.assertEquals( "§fTest string with §fa§f placeholder", TextComponent.toLegacyText( baseComponents ) );
+         assertEquals( "Test string with a placeholder", TextComponent.toPlainText( baseComponents ) );
+         assertEquals( "§fTest string with §fa§f placeholder", TextComponent.toLegacyText( baseComponents ) );
      }
 +
 +    @Test
 +    public void testEscapedPercentInPlainText()
 +    {
 +        TranslatableComponent testComponent = new TranslatableComponent( "Test string with %% sign" );
-+        Assert.assertEquals( "Test string with % sign", testComponent.toPlainText() );
-+        Assert.assertEquals( "§fTest string with §f%§f sign", testComponent.toLegacyText() );
++        assertEquals( "Test string with % sign", testComponent.toPlainText() );
++        assertEquals( "§fTest string with §f%§f sign", testComponent.toLegacyText() );
 +    }
  }
 -- 
-2.42.0
+2.34.1
 

--- a/BungeeCord-Patches/0018-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0018-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From 67b70e860e249dffbcb66046988fc0335bee1ef0 Mon Sep 17 00:00:00 2001
+From 656fe23535c2beac30d1d1cf134ec63e690f28c6 Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -57,10 +57,10 @@ index 107ff484..68687242 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index cfad8f53..10df98ff 100644
+index 2ba688f1..e333a7d3 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -362,6 +362,6 @@ public class UpstreamBridge extends PacketHandler
+@@ -365,6 +365,6 @@ public class UpstreamBridge extends PacketHandler
      @Override
      public String toString()
      {
@@ -69,5 +69,5 @@ index cfad8f53..10df98ff 100644
      }
  }
 -- 
-2.42.0
+2.34.1
 

--- a/BungeeCord-Patches/0021-Better-Decompression-Sanity.patch
+++ b/BungeeCord-Patches/0021-Better-Decompression-Sanity.patch
@@ -1,4 +1,4 @@
-From a476bbb603de2235e9f1dde545878e2ecd69cd30 Mon Sep 17 00:00:00 2001
+From b34e416dfd250b7d97c1ad1c810016203d9e53ab Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Fri, 18 Mar 2016 10:53:24 -0700
 Subject: [PATCH] Better Decompression Sanity
@@ -45,10 +45,10 @@ index 445ee947..eaedf4bc 100644
                  out.add( decompressed );
                  decompressed = null;
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
-index 915f8a7b..f3fe5061 100644
+index e8d5ed19..00e03bae 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/ChannelWrapper.java
-@@ -176,7 +176,7 @@ public class ChannelWrapper
+@@ -181,7 +181,7 @@ public class ChannelWrapper
  
          if ( ch.pipeline().get( PacketDecompressor.class ) == null && compressionThreshold >= 0 )
          {
@@ -58,5 +58,5 @@ index 915f8a7b..f3fe5061 100644
          if ( compressionThreshold < 0 )
          {
 -- 
-2.42.0
+2.34.1
 

--- a/BungeeCord-Patches/0050-Add-exception-reporting-event.patch
+++ b/BungeeCord-Patches/0050-Add-exception-reporting-event.patch
@@ -1,4 +1,4 @@
-From 119f063e02dec807420e098e1e4b8b1675ab115d Mon Sep 17 00:00:00 2001
+From 525b05ca4be2f52ce7819bda4bc52ddb2868c8cf Mon Sep 17 00:00:00 2001
 From: theminecoder <theminecoder.dev@gmail.com>
 Date: Wed, 22 Apr 2020 14:00:44 +1000
 Subject: [PATCH] Add exception reporting event
@@ -589,7 +589,7 @@ index 00000000..088fe9b7
 +
 +}
 diff --git a/event/src/test/java/net/md_5/bungee/event/EventBusTest.java b/event/src/test/java/net/md_5/bungee/event/EventBusTest.java
-index 2c737675..72f14937 100644
+index da2aa05d..712da5ae 100644
 --- a/event/src/test/java/net/md_5/bungee/event/EventBusTest.java
 +++ b/event/src/test/java/net/md_5/bungee/event/EventBusTest.java
 @@ -14,14 +14,14 @@ public class EventBusTest
@@ -598,7 +598,7 @@ index 2c737675..72f14937 100644
          bus.register( this );
 -        bus.post( new FirstEvent() );
 +        bus.post( new FirstEvent(), null ); // Waterfall - We dont need an exception handler here
-         Assert.assertEquals( 0, latch.getCount() );
+         assertEquals( 0, latch.getCount() );
      }
  
      @EventHandler
@@ -606,7 +606,7 @@ index 2c737675..72f14937 100644
      {
 -        bus.post( new SecondEvent() );
 +        bus.post( new SecondEvent(), null ); // Waterfall - We dont need an exception handler here
-         Assert.assertEquals( 1, latch.getCount() );
+         assertEquals( 1, latch.getCount() );
          latch.countDown();
      }
 @@ -39,4 +39,5 @@ public class EventBusTest
@@ -616,7 +616,7 @@ index 2c737675..72f14937 100644
 +
  }
 diff --git a/event/src/test/java/net/md_5/bungee/event/EventPriorityTest.java b/event/src/test/java/net/md_5/bungee/event/EventPriorityTest.java
-index 351d3724..88f1346f 100644
+index 3c5d45ea..7467540a 100644
 --- a/event/src/test/java/net/md_5/bungee/event/EventPriorityTest.java
 +++ b/event/src/test/java/net/md_5/bungee/event/EventPriorityTest.java
 @@ -15,7 +15,7 @@ public class EventPriorityTest
@@ -625,11 +625,11 @@ index 351d3724..88f1346f 100644
          bus.register( new EventPriorityListenerPartner() );
 -        bus.post( new PriorityTestEvent() );
 +        bus.post( new PriorityTestEvent(), null ); // Waterfall - We dont need an exception handler here
-         Assert.assertEquals( 0, latch.getCount() );
+         assertEquals( 0, latch.getCount() );
      }
  
 diff --git a/event/src/test/java/net/md_5/bungee/event/UnregisteringListenerTest.java b/event/src/test/java/net/md_5/bungee/event/UnregisteringListenerTest.java
-index fbfbd546..ae85a1d4 100644
+index 014de202..40792a68 100644
 --- a/event/src/test/java/net/md_5/bungee/event/UnregisteringListenerTest.java
 +++ b/event/src/test/java/net/md_5/bungee/event/UnregisteringListenerTest.java
 @@ -13,7 +13,7 @@ public class UnregisteringListenerTest
@@ -695,5 +695,5 @@ index 38b75b51..02ec98fc 100644
  
              // If we have a period of 0 or less, only run once
 -- 
-2.42.0
+2.34.1
 


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
497c6879 Add (hopefully temporary) queue for plugin messages to server
7b27dfaf #3522: Revert "#3518: Bump io.netty:netty-bom from 4.1.97.Final to 4.1.98.Final"
f9b75c4a Update tests to JUnit 5