### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0007-Fixup-ProtocolConstants.patch
+++ b/BungeeCord-Patches/0007-Fixup-ProtocolConstants.patch
@@ -1,14 +1,14 @@
-From 6420147c00011f92af85e62463d3a88048b96d32 Mon Sep 17 00:00:00 2001
+From 41b5d168431b57ab75c13f908fdfec83b6081f19 Mon Sep 17 00:00:00 2001
 From: Troy Frew <fuzzy_bot@arenaga.me>
 Date: Tue, 15 Nov 2016 09:07:51 -0500
 Subject: [PATCH] Fixup ProtocolConstants
 
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
-index d92a66d9..fedf6e99 100644
+index 6cb4c798..680af7d3 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
-@@ -115,6 +115,16 @@ public class ProtocolConstants
+@@ -116,6 +116,16 @@ public class ProtocolConstants
          SUPPORTED_VERSION_IDS = supportedVersionIds.build();
      }
  
@@ -26,5 +26,5 @@ index d92a66d9..fedf6e99 100644
      {
  
 -- 
-2.42.0
+2.39.2
 

--- a/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
+++ b/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
@@ -1,4 +1,4 @@
-From de632d241ae895ad859c98bf12954a4c092f3b62 Mon Sep 17 00:00:00 2001
+From 27ac1313bc044e08eed698e65f5377ac69f0f31a Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 3 May 2016 20:31:52 -0700
 Subject: [PATCH] Don't access a ByteBuf's underlying array
@@ -43,10 +43,10 @@ index 70b292f0..91f71c09 100644
       * Allow this packet to be sent as an "extended" packet.
       */
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 6d660bab..137d93cb 100644
+index dc6a5a8f..d11f73fc 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -267,7 +267,7 @@ public class ServerConnector extends PacketHandler
+@@ -268,7 +268,7 @@ public class ServerConnector extends PacketHandler
  
                  ByteBuf brand = ByteBufAllocator.DEFAULT.heapBuffer();
                  DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")", brand );
@@ -56,10 +56,10 @@ index 6d660bab..137d93cb 100644
              }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 172cc8e5..a16c48bb 100644
+index 27737d1b..b7856d92 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -300,7 +300,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -313,7 +313,7 @@ public class DownstreamBridge extends PacketHandler
  
              brand = ByteBufAllocator.DEFAULT.heapBuffer();
              DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")" + " <- " + serverBrand, brand );
@@ -82,5 +82,5 @@ index 5b9c35d1..2d6885a9 100644
      {
          @Override
 -- 
-2.42.1
+2.39.2
 

--- a/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch
+++ b/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch
@@ -1,4 +1,4 @@
-From c8ca8bce23ed4223c0830d5ab3b2bed51c755e3d Mon Sep 17 00:00:00 2001
+From 2977421f05d7f1f017682147111f7274c3ba0b91 Mon Sep 17 00:00:00 2001
 From: Daniel Naylor <git@drnaylor.co.uk>
 Date: Tue, 25 Oct 2016 12:23:07 -0400
 Subject: [PATCH] Add support for FML with IP Forwarding enabled
@@ -12,7 +12,7 @@ However, there is now at least one Forge coremod that intends to support IP forw
 No breaking changes occur due to this patch.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 137d93cb..ce925db2 100644
+index d11f73fc..b684df7d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -7,6 +7,7 @@ import io.netty.buffer.ByteBufAllocator;
@@ -23,7 +23,7 @@ index 137d93cb..ce925db2 100644
  import java.util.Queue;
  import java.util.Set;
  import java.util.UUID;
-@@ -111,15 +112,39 @@ public class ServerConnector extends PacketHandler
+@@ -112,15 +113,39 @@ public class ServerConnector extends PacketHandler
              String newHost = copiedHandshake.getHost() + "\00" + AddressUtil.sanitizeAddress( user.getAddress() ) + "\00" + user.getUUID();
  
              LoginResult profile = user.getPendingConnection().getLoginProfile();
@@ -101,5 +101,5 @@ index 6dca2048..f5253b89 100644
       * The FML 1.8 handshake token.
       */
 -- 
-2.42.1
+2.39.2
 

--- a/BungeeCord-Patches/0015-Micro-optimizations.patch
+++ b/BungeeCord-Patches/0015-Micro-optimizations.patch
@@ -1,4 +1,4 @@
-From 899f2a62a91d604866e2a5a85378b2fe9bc30aa0 Mon Sep 17 00:00:00 2001
+From b5d564124854f1fc8aedc8b5302d4c8098c6de8b Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Tue, 19 Jan 2016 15:13:29 -0700
 Subject: [PATCH] Micro-optimizations
@@ -8,10 +8,10 @@ Subject: [PATCH] Micro-optimizations
 - Don't create a data input stream for every plugin message we get from servers
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index b8248ec4..23e7b6d8 100644
+index b7856d92..61ce9ed6 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -282,7 +282,6 @@ public class DownstreamBridge extends PacketHandler
+@@ -295,7 +295,6 @@ public class DownstreamBridge extends PacketHandler
      @SuppressWarnings("checkstyle:avoidnestedblocks")
      public void handle(PluginMessage pluginMessage) throws Exception
      {
@@ -19,7 +19,7 @@ index b8248ec4..23e7b6d8 100644
          PluginMessageEvent event = new PluginMessageEvent( server, con, pluginMessage.getTag(), pluginMessage.getData().clone() );
  
          if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
-@@ -309,6 +308,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -322,6 +321,7 @@ public class DownstreamBridge extends PacketHandler
  
          if ( pluginMessage.getTag().equals( "BungeeCord" ) )
          {
@@ -28,5 +28,5 @@ index b8248ec4..23e7b6d8 100644
              String subChannel = in.readUTF();
  
 -- 
-2.42.0
+2.39.2
 

--- a/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From c900fddebb1bbe7539c16204f74c9565840d4427 Mon Sep 17 00:00:00 2001
+From 5bcf70b740e218893c47983c08cad7e9e6beb77c Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -37,10 +37,10 @@ index d79d5e5c..250e7620 100644
              {
                  packet.read( in, protocol, prot.getDirection(), protocolVersion );
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-index 2eeca50b..9bd62ceb 100644
+index cc08447c..b55ebede 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-@@ -751,14 +751,23 @@ public enum Protocol
+@@ -770,14 +770,23 @@ public enum Protocol
              return protocol;
          }
  
@@ -66,10 +66,10 @@ index 2eeca50b..9bd62ceb 100644
                  throw new BadPacketException( "Packet with id " + id + " outside of range" );
              }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index ce925db2..6db704bd 100644
+index b684df7d..4894b3ee 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -224,6 +224,12 @@ public class ServerConnector extends PacketHandler
+@@ -225,6 +225,12 @@ public class ServerConnector extends PacketHandler
      public static void handleLogin(ProxyServer bungee, ChannelWrapper ch, UserConnection user, BungeeServerInfo target, ForgeServerHandler handshakeHandler, ServerConnection server, Login login) throws Exception
      {
          ServerConnectedEvent event = new ServerConnectedEvent( user, server );
@@ -100,5 +100,5 @@ index 9a47f2ec..b768d54a 100644
          {
              rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
 -- 
-2.42.1
+2.39.2
 

--- a/BungeeCord-Patches/0018-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0018-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From 1932cedf8e7963d4f1107147f37d4376fa716995 Mon Sep 17 00:00:00 2001
+From 3709ce1b52ab1be9e6c6c228843138f44ec23b10 Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -7,10 +7,10 @@ This functionality of this patch was adopted upstream, however, this
 patch remains for a few misc improvements around here
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 6db704bd..53eac723 100644
+index 4894b3ee..a8e938be 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -507,6 +507,6 @@ public class ServerConnector extends PacketHandler
+@@ -514,6 +514,6 @@ public class ServerConnector extends PacketHandler
      @Override
      public String toString()
      {
@@ -19,10 +19,10 @@ index 6db704bd..53eac723 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 6f74ed82..6f447b6d 100644
+index 61ce9ed6..976c8e26 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -777,6 +777,6 @@ public class DownstreamBridge extends PacketHandler
+@@ -790,6 +790,6 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public String toString()
      {
@@ -69,5 +69,5 @@ index 84be12e5..6acbf7bf 100644
      }
  }
 -- 
-2.42.1
+2.39.2
 

--- a/BungeeCord-Patches/0025-Improve-ServerKickEvent.patch
+++ b/BungeeCord-Patches/0025-Improve-ServerKickEvent.patch
@@ -1,4 +1,4 @@
-From 2edfba28d1e4a68d6253a0db84a2685af6882041 Mon Sep 17 00:00:00 2001
+From 18dec93180b89dc7f7bcda81cb5596ed53d38b33 Mon Sep 17 00:00:00 2001
 From: Nathan Poirier <nathan@poirier.io>
 Date: Tue, 28 Jun 2016 23:00:49 -0500
 Subject: [PATCH] Improve ServerKickEvent
@@ -68,10 +68,10 @@ index 3f9efaa8..5d2597ad 100644
      /**
       * @return the kick reason
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 53eac723..a1f5c709 100644
+index a8e938be..43af8888 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -424,7 +424,7 @@ public class ServerConnector extends PacketHandler
+@@ -431,7 +431,7 @@ public class ServerConnector extends PacketHandler
          ServerKickEvent event = new ServerKickEvent( user, target, new BaseComponent[]
          {
              kick.getMessage()
@@ -81,10 +81,10 @@ index 53eac723..a1f5c709 100644
          {
              // Pre cancel the event if we are going to try another server
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 6f447b6d..3df0f26c 100644
+index 976c8e26..7e416a6d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -97,16 +97,19 @@ public class DownstreamBridge extends PacketHandler
+@@ -98,16 +98,19 @@ public class DownstreamBridge extends PacketHandler
              return;
          }
  
@@ -109,7 +109,7 @@ index 6f447b6d..3df0f26c 100644
      }
  
      @Override
-@@ -121,7 +124,19 @@ public class DownstreamBridge extends PacketHandler
+@@ -122,7 +125,19 @@ public class DownstreamBridge extends PacketHandler
  
          if ( !server.isObsolete() )
          {
@@ -130,7 +130,7 @@ index 6f447b6d..3df0f26c 100644
          }
  
          ServerDisconnectEvent serverDisconnectEvent = new ServerDisconnectEvent( con, server.getInfo() );
-@@ -620,10 +635,14 @@ public class DownstreamBridge extends PacketHandler
+@@ -633,10 +648,14 @@ public class DownstreamBridge extends PacketHandler
      public void handle(Kick kick) throws Exception
      {
          ServerInfo def = con.updateAndGetNextServer( server.getInfo() );
@@ -147,5 +147,5 @@ index 6f447b6d..3df0f26c 100644
          {
              con.connectNow( event.getCancelServer(), ServerConnectEvent.Reason.KICK_REDIRECT );
 -- 
-2.42.1
+2.39.2
 

--- a/BungeeCord-Patches/0030-Fix-potion-race-condition-on-Forge-1.8.9.patch
+++ b/BungeeCord-Patches/0030-Fix-potion-race-condition-on-Forge-1.8.9.patch
@@ -1,14 +1,14 @@
-From 8eea3ccfded59af6e76549d279cf0def408a10ba Mon Sep 17 00:00:00 2001
+From d875a31567c80968074c822239555a0db45bbd6f Mon Sep 17 00:00:00 2001
 From: Aaron Hill <aa1ronham@gmail.com>
 Date: Thu, 15 Sep 2016 22:38:37 +0200
 Subject: [PATCH] Fix potion race condition on Forge 1.8.9
 
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
-index 0f8f5885..b3c8c6e2 100644
+index 4383dbb5..2b4e4298 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
-@@ -238,4 +238,14 @@ public abstract class AbstractPacketHandler
+@@ -243,4 +243,14 @@ public abstract class AbstractPacketHandler
      public void handle(FinishConfiguration finishConfiguration) throws Exception
      {
      }
@@ -117,7 +117,7 @@ index 00000000..7ed2dc3a
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 7a62088d..cff35a06 100644
+index f7160a66..a5ddcdc3 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 @@ -1,7 +1,9 @@
@@ -142,10 +142,10 @@ index 7a62088d..cff35a06 100644
      @Setter
      private String lastCommandTabbed;
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index f461c096..80275a15 100644
+index 7e416a6d..8a10b057 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -740,6 +740,32 @@ public class DownstreamBridge extends PacketHandler
+@@ -753,6 +753,32 @@ public class DownstreamBridge extends PacketHandler
          }
      }
  
@@ -216,5 +216,5 @@ index d15044f4..bea2bbff 100644
       * Sends the server mod list to the client, or stores it for sending later.
       *
 -- 
-2.42.0
+2.39.2
 

--- a/BungeeCord-Patches/0044-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0044-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From 864a8a831340faf45c4db8f6db6dd25e078e72d5 Mon Sep 17 00:00:00 2001
+From 98b9ef9fb61e64abb7be8019bee05b2c0965dd13 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -57,10 +57,10 @@ index 4ff8da6d..e860214f 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index a1f5c709..f43aee8c 100644
+index 43af8888..bc2c4d03 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -254,7 +254,8 @@ public class ServerConnector extends PacketHandler
+@@ -255,7 +255,8 @@ public class ServerConnector extends PacketHandler
              ch.write( new PluginMessage( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13 ? "minecraft:register" : "REGISTER", Joiner.on( "\0" ).join( registeredChannels ).getBytes( StandardCharsets.UTF_8 ), false ) );
          }
  
@@ -70,7 +70,7 @@ index a1f5c709..f43aee8c 100644
          {
              ch.write( user.getSettings() );
          }
-@@ -309,6 +310,7 @@ public class ServerConnector extends PacketHandler
+@@ -310,6 +311,7 @@ public class ServerConnector extends PacketHandler
              user.getTabListHandler().onServerChange();
  
              Scoreboard serverScoreboard = user.getServerSentScoreboard();
@@ -78,7 +78,7 @@ index a1f5c709..f43aee8c 100644
              for ( Objective objective : serverScoreboard.getObjectives() )
              {
                  user.unsafe().sendPacket( new ScoreboardObjective(
-@@ -326,6 +328,7 @@ public class ServerConnector extends PacketHandler
+@@ -333,6 +335,7 @@ public class ServerConnector extends PacketHandler
              {
                  user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.Team( team.getName() ) );
              }
@@ -86,7 +86,7 @@ index a1f5c709..f43aee8c 100644
              serverScoreboard.clear();
  
              for ( UUID bossbar : user.getSentBossBars() )
-@@ -344,13 +347,34 @@ public class ServerConnector extends PacketHandler
+@@ -351,13 +354,34 @@ public class ServerConnector extends PacketHandler
              }
  
              user.setDimensionChange( true );
@@ -138,10 +138,10 @@ index a5ddcdc3..1d3b7a9d 100644
 +    // Waterfall end
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 4b812092..e8c7e2f2 100644
+index 8a10b057..249c3f46 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -744,6 +744,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -757,6 +757,7 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(net.md_5.bungee.protocol.packet.EntityEffect entityEffect) throws Exception
      {
@@ -149,7 +149,7 @@ index 4b812092..e8c7e2f2 100644
          // Don't send any potions when switching between servers (which involves a handshake), which can trigger a race
          // condition on the client.
          if (this.con.getForgeClientHandler().isForgeUser() && !this.con.getForgeClientHandler().isHandshakeComplete()) {
-@@ -755,6 +756,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -768,6 +769,7 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(net.md_5.bungee.protocol.packet.EntityRemoveEffect removeEffect) throws Exception
      {
@@ -226,5 +226,5 @@ index 00000000..cb81d1dd
 +// Waterfall end
 \ No newline at end of file
 -- 
-2.42.1
+2.39.2
 

--- a/BungeeCord-Patches/0045-Add-ProxyDefineCommandsEvent.patch
+++ b/BungeeCord-Patches/0045-Add-ProxyDefineCommandsEvent.patch
@@ -1,4 +1,4 @@
-From 0b970cb79fd1c2ecf5eee883f54b691554543a48 Mon Sep 17 00:00:00 2001
+From c6a05be943e92d56c54992c78cffa425239ee361 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Thu, 14 Mar 2019 07:44:06 +0000
 Subject: [PATCH] Add ProxyDefineCommandsEvent
@@ -54,10 +54,10 @@ index 00000000..1fd4fc90
 +
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index bc808b2c..2e427335 100644
+index 249c3f46..42232443 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -779,9 +779,25 @@ public class DownstreamBridge extends PacketHandler
+@@ -792,9 +792,25 @@ public class DownstreamBridge extends PacketHandler
      {
          boolean modified = false;
  
@@ -86,5 +86,5 @@ index bc808b2c..2e427335 100644
                  CommandNode dummy = LiteralArgumentBuilder.literal( command.getKey() ).executes( DUMMY_COMMAND )
                          .then( RequiredArgumentBuilder.argument( "args", StringArgumentType.greedyString() )
 -- 
-2.42.0
+2.39.2
 

--- a/BungeeCord-Patches/0048-Speed-up-some-common-exceptions.patch
+++ b/BungeeCord-Patches/0048-Speed-up-some-common-exceptions.patch
@@ -1,4 +1,4 @@
-From 8841640a739548c333344a4abdff6a2d8239c019 Mon Sep 17 00:00:00 2001
+From e34d073a76021f7595cd1ee98b4c149c75dd70b1 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 25 Nov 2019 19:54:06 +0000
 Subject: [PATCH] Speed up some common exceptions
@@ -67,12 +67,12 @@ index 6c0ef4df..f20104a2 100644
 +    // Waterfall end
  }
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
-index d7d5d849..1fdf7053 100644
+index 94613a0a..8751f271 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
-@@ -27,6 +27,9 @@ import se.llbit.nbt.Tag;
- public abstract class DefinedPacket
- {
+@@ -46,6 +46,9 @@ public abstract class DefinedPacket
+         }
+     }
  
 +    private static final boolean PROCESS_TRACES = Boolean.getBoolean("waterfall.bad-packet-traces");
 +    private static final BadPacketException OVERSIZED_VAR_INT_EXCEPTION = new BadPacketException( "VarInt too big" );
@@ -80,7 +80,7 @@ index d7d5d849..1fdf7053 100644
      public static void writeString(String s, ByteBuf buf)
      {
          writeString( s, buf, Short.MAX_VALUE );
-@@ -206,13 +209,18 @@ public abstract class DefinedPacket
+@@ -225,13 +228,18 @@ public abstract class DefinedPacket
          byte in;
          while ( true )
          {
@@ -195,5 +195,5 @@ index ac99d02c..0c1ecfb8 100644
  
              // Waterfall start
 -- 
-2.42.1
+2.39.2
 

--- a/BungeeCord-Patches/0051-Allow-to-disable-tablist-rewrite.patch
+++ b/BungeeCord-Patches/0051-Allow-to-disable-tablist-rewrite.patch
@@ -1,4 +1,4 @@
-From e6f5612067c9f90985f0e3d2f4359b176b2ac81d Mon Sep 17 00:00:00 2001
+From d910c426ae5512d9ed992bbbcd57d62fb7926c88 Mon Sep 17 00:00:00 2001
 From: xDark <aleshkailyashevich@gmail.com>
 Date: Fri, 31 May 2019 08:11:31 +0300
 Subject: [PATCH] Allow to disable tablist rewrite
@@ -50,10 +50,10 @@ index e860214f..b88e3c8a 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index e05e746c..006c7133 100644
+index 42232443..747916d1 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -173,8 +173,14 @@ public class DownstreamBridge extends PacketHandler
+@@ -174,8 +174,14 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(PlayerListItem playerList) throws Exception
      {
@@ -71,5 +71,5 @@ index e05e746c..006c7133 100644
  
      @Override
 -- 
-2.42.0
+2.39.2
 

--- a/BungeeCord-Patches/0052-Remove-version-from-brand-info.patch
+++ b/BungeeCord-Patches/0052-Remove-version-from-brand-info.patch
@@ -1,14 +1,14 @@
-From 20f457fb1fb59705bfdcdf18850ada9533d98b76 Mon Sep 17 00:00:00 2001
+From 14356d7b7316920c047225d153d5abc5411792a1 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sat, 20 Jun 2020 18:21:17 +0100
 Subject: [PATCH] Remove version from brand info
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 006c7133..485af04f 100644
+index 747916d1..d0496ab4 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -319,7 +319,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -332,7 +332,7 @@ public class DownstreamBridge extends PacketHandler
              Preconditions.checkState( !serverBrand.contains( bungee.getName() ), "Cannot connect proxy to itself!" );
  
              brand = ByteBufAllocator.DEFAULT.heapBuffer();
@@ -18,5 +18,5 @@ index 006c7133..485af04f 100644
              brand.release();
              // changes in the packet are ignored so we need to send it manually
 -- 
-2.42.0
+2.39.2
 

--- a/BungeeCord-Patches/0055-Additional-DoS-mitigations.patch
+++ b/BungeeCord-Patches/0055-Additional-DoS-mitigations.patch
@@ -1,4 +1,4 @@
-From 55d33b55acd0b62aa1afed32c926229200ae9e42 Mon Sep 17 00:00:00 2001
+From 9a0ea49743be5e1783cd701cda3757778bc198c5 Mon Sep 17 00:00:00 2001
 From: "Five (Xer)" <admin@fivepb.me>
 Date: Sat, 30 Jan 2021 18:04:14 +0100
 Subject: [PATCH] Additional DoS mitigations
@@ -8,10 +8,10 @@ Courtesy of Tux and the Velocity Contributors. See:
 https://github.com/VelocityPowered/Velocity/commit/5ceac16a821ea35572ff11412ace8929fd06e278
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
-index 1fdf7053..aac03774 100644
+index 8751f271..8c9714fd 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
-@@ -62,6 +62,7 @@ public abstract class DefinedPacket
+@@ -81,6 +81,7 @@ public abstract class DefinedPacket
          int len = readVarInt( buf );
          if ( len > maxLen * 3 )
          {
@@ -19,7 +19,7 @@ index 1fdf7053..aac03774 100644
              throw new OverflowPacketException( "Cannot receive string longer than " + maxLen * 3 + " (got " + len + " bytes)" );
          }
  
-@@ -70,6 +71,7 @@ public abstract class DefinedPacket
+@@ -89,6 +90,7 @@ public abstract class DefinedPacket
  
          if ( s.length() > maxLen )
          {
@@ -27,7 +27,7 @@ index 1fdf7053..aac03774 100644
              throw new OverflowPacketException( "Cannot receive string longer than " + maxLen + " (got " + s.length() + " characters)" );
          }
  
-@@ -499,4 +501,21 @@ public abstract class DefinedPacket
+@@ -550,4 +552,21 @@ public abstract class DefinedPacket
  
      @Override
      public abstract String toString();
@@ -257,5 +257,5 @@ index 738f0c92..ec33d337 100644
 +    // Waterfall end
  }
 -- 
-2.42.1
+2.39.2
 

--- a/BungeeCord-Patches/0061-Add-protocol-version-to-packet-not-found-message.patch
+++ b/BungeeCord-Patches/0061-Add-protocol-version-to-packet-not-found-message.patch
@@ -1,4 +1,4 @@
-From ce0afd13c32c6d7bc814b4727d465b5b579df1be Mon Sep 17 00:00:00 2001
+From b13c9df810ca47a2d64848f3b03f1048819df913 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 12 Jun 2022 06:45:54 +0100
 Subject: [PATCH] Add protocol version to packet not found message
@@ -6,7 +6,7 @@ Subject: [PATCH] Add protocol version to packet not found message
 Also avoids a double get, but, this is probably trivial
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-index 9bd62ceb..e1238e4c 100644
+index b55ebede..27d4c2c4 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 @@ -2,6 +2,8 @@ package net.md_5.bungee.protocol;
@@ -18,7 +18,7 @@ index 9bd62ceb..e1238e4c 100644
  import gnu.trove.map.TIntObjectMap;
  import gnu.trove.map.TObjectIntMap;
  import gnu.trove.map.hash.TIntObjectHashMap;
-@@ -832,9 +834,12 @@ public enum Protocol
+@@ -851,9 +853,12 @@ public enum Protocol
              {
                  throw new BadPacketException( "Unsupported protocol version" );
              }
@@ -34,5 +34,5 @@ index 9bd62ceb..e1238e4c 100644
      }
  }
 -- 
-2.42.0
+2.39.2
 

--- a/BungeeCord-Patches/0066-Prevent-proxy-commands-from-breaking-the-chat-chain-.patch
+++ b/BungeeCord-Patches/0066-Prevent-proxy-commands-from-breaking-the-chat-chain-.patch
@@ -1,14 +1,14 @@
-From 040e9cf5705093c527b80521d426a67e351728aa Mon Sep 17 00:00:00 2001
+From 87ff91f098c8cc5f1f6cbba5f4724552b3c8805c Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 15 Oct 2023 00:36:38 +0100
 Subject: [PATCH] Prevent proxy commands from breaking the chat chain system
 
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
-index b3c8c6e2..1eaebc2e 100644
+index 2b4e4298..1fad0818 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/AbstractPacketHandler.java
-@@ -247,5 +247,9 @@ public abstract class AbstractPacketHandler
+@@ -252,5 +252,9 @@ public abstract class AbstractPacketHandler
      public void handle(net.md_5.bungee.protocol.packet.EntityRemoveEffect removeEffect) throws Exception
      {
      }
@@ -19,10 +19,10 @@ index b3c8c6e2..1eaebc2e 100644
      // Waterfall end
  }
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-index e1238e4c..d815864b 100644
+index 27d4c2c4..bd66e7a5 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/Protocol.java
-@@ -477,6 +477,13 @@ public enum Protocol
+@@ -496,6 +496,13 @@ public enum Protocol
                      map( ProtocolConstants.MINECRAFT_1_19, 0x04 ),
                      map( ProtocolConstants.MINECRAFT_1_19_1, 0x05 )
              );
@@ -125,5 +125,5 @@ index 05e3bd21..dff5e283 100644
          }
          throw CancelSendSignal.INSTANCE;
 -- 
-2.42.1
+2.39.2
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Waterfall requires **Java 8** or above.
 <dependency>
     <groupId>io.github.waterfallmc</groupId>
     <artifactId>waterfall-api</artifactId>
-    <version>1.19-R0.1-SNAPSHOT</version>
+    <version>1.20-R0.1-SNAPSHOT</version>
     <scope>provided</scope>
 </dependency>
  ```
@@ -58,7 +58,7 @@ repositories {
  * Artifact:
 ```groovy
 dependencies {
-    compileOnly 'io.github.waterfallmc:waterfall-api:1.19-R0.1-SNAPSHOT'
+    compileOnly 'io.github.waterfallmc:waterfall-api:1.20-R0.1-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
8ce7a7f8 Minecraft 1.20.3 support
e1462ccd Minecraft 1.20.3-rc1 support
70f346c1 Fix extra write in ScoreboardScore packet 197bf13a Minecraft 1.20.3-pre2 support