### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0001-POM-Changes.patch
+++ b/BungeeCord-Patches/0001-POM-Changes.patch
@@ -1,4 +1,4 @@
-From be89fec835ee9a14d22f1bb7ae33a36e887258fa Mon Sep 17 00:00:00 2001
+From 089ceef7ec58a1d92d51e215efff4dd22c296b4e Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 19:33:31 +0200
 Subject: [PATCH] POM Changes
@@ -514,7 +514,7 @@ index 56d505ab..f7bae2fe 100644
      <dependencies>
          <dependency>
 diff --git a/pom.xml b/pom.xml
-index 5d52cc90..87ab1b76 100644
+index 5ceacdd8..a19d10da 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,18 +3,18 @@
@@ -700,7 +700,7 @@ index 6f5acbc2..db62c340 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index cd90feeb..d8aae8fa 100644
+index 574e36c9..63bc0b32 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
 @@ -4,18 +4,18 @@
@@ -727,8 +727,8 @@ index cd90feeb..d8aae8fa 100644
      <description>Proxy component of the Elastic Portal Suite</description>
  
      <properties>
-@@ -52,38 +52,38 @@
-             <scope>compile</scope>
+@@ -64,38 +64,38 @@
+             <classifier>linux-aarch_64</classifier>
          </dependency>
          <dependency>
 -            <groupId>net.md-5</groupId>

--- a/BungeeCord-Patches/0002-Copy-license-files-into-jar.patch
+++ b/BungeeCord-Patches/0002-Copy-license-files-into-jar.patch
@@ -1,14 +1,14 @@
-From 42086afe5cb8e7ec279421c3caf74fdf0ebbc413 Mon Sep 17 00:00:00 2001
+From 9e23f15ddcedd1ddda23827e564ecd3058687010 Mon Sep 17 00:00:00 2001
 From: Mark Vainomaa <mikroskeem@mikroskeem.eu>
 Date: Wed, 18 Jul 2018 20:23:03 +0300
 Subject: [PATCH] Copy license files into jar
 
 
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index d1c4570d..fe1506e4 100644
+index 63bc0b32..a70f8c5c 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
-@@ -119,4 +119,26 @@
+@@ -131,4 +131,26 @@
              <scope>runtime</scope>
          </dependency>
      </dependencies>
@@ -36,5 +36,5 @@ index d1c4570d..fe1506e4 100644
 +    <!-- Waterfall end -->
  </project>
 -- 
-2.43.0
+2.44.0
 

--- a/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
+++ b/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
@@ -1,4 +1,4 @@
-From 0cdb5fce7e1e629416846d4493d8eee5458b1263 Mon Sep 17 00:00:00 2001
+From 399142c001df2d50e1cba9eee822388bc39b12ab Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 3 May 2016 20:31:52 -0700
 Subject: [PATCH] Don't access a ByteBuf's underlying array
@@ -43,7 +43,7 @@ index 70b292f0..91f71c09 100644
       * Allow this packet to be sent as an "extended" packet.
       */
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 47e06dcd..c60c7dd7 100644
+index abdbfd1d..04bd6778 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -277,7 +277,7 @@ public class ServerConnector extends PacketHandler
@@ -56,7 +56,7 @@ index 47e06dcd..c60c7dd7 100644
              }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 27737d1b..b7856d92 100644
+index 4684bfd8..63be43eb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 @@ -313,7 +313,7 @@ public class DownstreamBridge extends PacketHandler
@@ -69,10 +69,10 @@ index 27737d1b..b7856d92 100644
              // changes in the packet are ignored so we need to send it manually
              con.unsafe().sendPacket( pluginMessage );
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index 5b9c35d1..2d6885a9 100644
+index 25f045be..544d34ed 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-@@ -50,7 +50,7 @@ import net.md_5.bungee.protocol.Varint21LengthFieldPrepender;
+@@ -55,7 +55,7 @@ import net.md_5.bungee.protocol.Varint21LengthFieldPrepender;
  public class PipelineUtils
  {
  
@@ -82,5 +82,5 @@ index 5b9c35d1..2d6885a9 100644
      {
          @Override
 -- 
-2.43.0.windows.1
+2.44.0
 

--- a/BungeeCord-Patches/0014-Enable-TCP_NODELAY.patch
+++ b/BungeeCord-Patches/0014-Enable-TCP_NODELAY.patch
@@ -1,4 +1,4 @@
-From 191e3b8b67359f39bac4d62ee57796eb1e793ce3 Mon Sep 17 00:00:00 2001
+From 8b98ff8d43ae4244bb9700d76f6d8b02270bc6fd Mon Sep 17 00:00:00 2001
 From: Harry <me@harry5573.uk>
 Date: Sun, 24 Jan 2016 15:13:29 -0700
 Subject: [PATCH] Enable TCP_NODELAY.
@@ -6,10 +6,10 @@ Subject: [PATCH] Enable TCP_NODELAY.
 This is enabled by default on CraftBukkit/Spigot >= 1.8 and may help with network performance.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index 2d6885a9..3f30da0c 100644
+index 544d34ed..6a0d3351 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-@@ -174,6 +174,7 @@ public class PipelineUtils
+@@ -195,6 +195,7 @@ public class PipelineUtils
              {
                  // IP_TOS is not supported (Windows XP / Windows Server 2003)
              }
@@ -18,5 +18,5 @@ index 2d6885a9..3f30da0c 100644
              ch.config().setWriteBufferWaterMark( MARK );
  
 -- 
-2.43.0
+2.44.0
 

--- a/BungeeCord-Patches/0033-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
+++ b/BungeeCord-Patches/0033-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
@@ -1,4 +1,4 @@
-From 96ff42638e839e92b966aaa95a50f8ee81cd16ea Mon Sep 17 00:00:00 2001
+From f8b0691ca00ae4968acfacbc9d4a86ec2e078d88 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 22 Sep 2017 12:46:47 +0200
 Subject: [PATCH] Use Log4j2 for logging and TerminalConsoleAppender for
@@ -233,7 +233,7 @@ index 00000000..cfd039cd
 +    </Loggers>
 +</Configuration>
 diff --git a/pom.xml b/pom.xml
-index 87ab1b76..f8491614 100644
+index a19d10da..715d3e11 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -48,12 +48,13 @@
@@ -253,10 +253,10 @@ index 87ab1b76..f8491614 100644
      </modules>
  
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index 1d2b4ec9..15887222 100644
+index 216e894e..95703fee 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
-@@ -71,7 +71,7 @@
+@@ -83,7 +83,7 @@
          </dependency>
          <dependency>
              <groupId>io.github.waterfallmc</groupId>
@@ -265,7 +265,7 @@ index 1d2b4ec9..15887222 100644
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
-@@ -93,12 +93,13 @@
+@@ -105,12 +105,13 @@
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
@@ -280,7 +280,7 @@ index 1d2b4ec9..15887222 100644
          <dependency>
              <groupId>net.sf.jopt-simple</groupId>
              <artifactId>jopt-simple</artifactId>
-@@ -130,6 +131,35 @@
+@@ -142,6 +143,35 @@
              <version>1.9.18</version>
              <scope>runtime</scope>
          </dependency>

--- a/BungeeCord-Patches/0048-ConnectionInitEvent.patch
+++ b/BungeeCord-Patches/0048-ConnectionInitEvent.patch
@@ -1,4 +1,4 @@
-From 838b44a67a3b27848d8185e5114e2dc9f8067afc Mon Sep 17 00:00:00 2001
+From bf64d9cf56589f4dc98386425c290d03b14837fc Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 2 Dec 2019 11:35:17 +0000
 Subject: [PATCH] ConnectionInitEvent
@@ -67,7 +67,7 @@ index 00000000..6e79675f
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index 3f30da0c..af65e192 100644
+index 6a0d3351..3b157d79 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 @@ -1,6 +1,7 @@
@@ -78,7 +78,7 @@ index 3f30da0c..af65e192 100644
  import io.netty.buffer.PooledByteBufAllocator;
  import io.netty.channel.Channel;
  import io.netty.channel.ChannelException;
-@@ -63,7 +64,6 @@ public class PipelineUtils
+@@ -68,7 +69,6 @@ public class PipelineUtils
                  ch.close();
                  return;
              }
@@ -86,7 +86,7 @@ index 3f30da0c..af65e192 100644
              ListenerInfo listener = ch.attr( LISTENER ).get();
  
              if ( BungeeCord.getInstance().getPluginManager().callEvent( new ClientConnectEvent( remoteAddress, listener ) ).isCancelled() )
-@@ -72,7 +72,21 @@ public class PipelineUtils
+@@ -77,7 +77,21 @@ public class PipelineUtils
                  return;
              }
  
@@ -108,7 +108,7 @@ index 3f30da0c..af65e192 100644
              ch.pipeline().addBefore( FRAME_DECODER, LEGACY_DECODER, new LegacyDecoder() );
              ch.pipeline().addAfter( FRAME_DECODER, PACKET_DECODER, new MinecraftDecoder( Protocol.HANDSHAKE, true, ProxyServer.getInstance().getProtocolVersion() ) );
              ch.pipeline().addAfter( FRAME_PREPENDER, PACKET_ENCODER, new MinecraftEncoder( Protocol.HANDSHAKE, true, ProxyServer.getInstance().getProtocolVersion() ) );
-@@ -83,6 +97,9 @@ public class PipelineUtils
+@@ -88,6 +102,9 @@ public class PipelineUtils
              {
                  ch.pipeline().addFirst( new HAProxyMessageDecoder() );
              }

--- a/BungeeCord-Patches/0063-Replace-reflection-inside-netty-with-ChannelFactory.patch
+++ b/BungeeCord-Patches/0063-Replace-reflection-inside-netty-with-ChannelFactory.patch
@@ -1,4 +1,4 @@
-From 25abd4454ef1e0caeeaad0e21866e8612528d916 Mon Sep 17 00:00:00 2001
+From 429d77cd283c12f043fb0da276a0a3856aa31ab2 Mon Sep 17 00:00:00 2001
 From: Janmm14 <gitconfig1@janmm14.de>
 Date: Mon, 21 Jun 2021 23:43:39 +0200
 Subject: [PATCH] Replace reflection inside netty with ChannelFactory.
@@ -69,7 +69,7 @@ index 37337429..c3683c30 100644
      }
      // Waterfall End
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index af65e192..6a045d16 100644
+index 3b157d79..52c308f7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 @@ -5,6 +5,7 @@ import io.github.waterfallmc.waterfall.event.ConnectionInitEvent;
@@ -80,10 +80,10 @@ index af65e192..6a045d16 100644
  import io.netty.channel.ChannelInitializer;
  import io.netty.channel.ChannelOption;
  import io.netty.channel.EventLoopGroup;
-@@ -119,6 +120,12 @@ public class PipelineUtils
-     public static final String LEGACY_KICKER = "legacy-kick";
+@@ -125,6 +126,12 @@ public class PipelineUtils
  
      private static boolean epoll;
+     private static boolean io_uring;
 +    // Waterfall start: netty reflection -> factory
 +    private static final ChannelFactory<? extends ServerChannel> serverChannelFactory;
 +    private static final ChannelFactory<? extends ServerChannel> serverChannelDomainFactory;
@@ -93,21 +93,21 @@ index af65e192..6a045d16 100644
  
      static
      {
-@@ -134,6 +141,12 @@ public class PipelineUtils
-                 ProxyServer.getInstance().getLogger().log( Level.WARNING, "Epoll is not working, falling back to NIO: {0}", Util.exception( Epoll.unavailabilityCause() ) );
+@@ -155,6 +162,12 @@ public class PipelineUtils
+                 }
              }
          }
 +        // Waterfall start: netty reflection -> factory
-+        serverChannelFactory = epoll ? EpollServerSocketChannel::new : NioServerSocketChannel::new;
-+        serverChannelDomainFactory = epoll ? EpollServerDomainSocketChannel::new : null;
-+        channelFactory = epoll ? EpollSocketChannel::new : NioSocketChannel::new;
-+        channelDomainFactory = epoll ? EpollDomainSocketChannel::new : null;
++        serverChannelFactory = io_uring ? IOUringServerSocketChannel::new : epoll ? EpollServerSocketChannel::new : NioServerSocketChannel::new;
++        serverChannelDomainFactory = io_uring ? IOUringServerSocketChannel::new : epoll ? EpollServerDomainSocketChannel::new : null;
++        channelFactory = io_uring ? IOUringSocketChannel::new : epoll ? EpollSocketChannel::new : NioSocketChannel::new;
++        channelDomainFactory = io_uring ? IOUringSocketChannel::new : epoll ? EpollDomainSocketChannel::new : null;
 +        // Waterfall end
      }
  
      public static EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory)
-@@ -165,6 +178,34 @@ public class PipelineUtils
-         return epoll ? EpollSocketChannel.class : NioSocketChannel.class;
+@@ -186,6 +199,34 @@ public class PipelineUtils
+         return io_uring ? IOUringSocketChannel.class : epoll ? EpollSocketChannel.class : NioSocketChannel.class;
      }
  
 +    // Waterfall start: netty reflection -> factory
@@ -140,7 +140,7 @@ index af65e192..6a045d16 100644
 +
      public static Class<? extends DatagramChannel> getDatagramChannel()
      {
-         return epoll ? EpollDatagramChannel.class : NioDatagramChannel.class;
+         return io_uring ? IOUringDatagramChannel.class : epoll ? EpollDatagramChannel.class : NioDatagramChannel.class;
 -- 
 2.44.0
 


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
5e25c63c #3646: Add experimental io_uring support
bd963501 #3644: Bump org.apache.maven.plugins:maven-source-plugin from 3.3.0 to 3.3.1 da795a70 Minecraft 24w14a support

----

This generally looks fine, but, I'm not 100% and do not have the capacity to test right now