### PR TITLE
Updated Upstream (BungeeCord)

### DIFF
--- a/BungeeCord-Patches/0001-POM-Changes.patch
+++ b/BungeeCord-Patches/0001-POM-Changes.patch
@@ -1,4 +1,4 @@
-From efabb933f6d667f0099adda5311cd873b06e6287 Mon Sep 17 00:00:00 2001
+From ceb03602d7da765f9580ea9be7f06a1bb556c2c9 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 19:33:31 +0200
 Subject: [PATCH] POM Changes
@@ -7,7 +7,7 @@ Subject: [PATCH] POM Changes
 - Deploy to papermc mvn repo
 
 diff --git a/api/pom.xml b/api/pom.xml
-index 1d292359..00d6a6f6 100644
+index b050e847..26ad9ac8 100644
 --- a/api/pom.xml
 +++ b/api/pom.xml
 @@ -4,42 +4,42 @@
@@ -18,7 +18,7 @@ index 1d292359..00d6a6f6 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -26,7 +26,7 @@ index 1d292359..00d6a6f6 100644
 -    <artifactId>bungeecord-api</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-api</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-API</name>
@@ -67,7 +67,7 @@ index 1d292359..00d6a6f6 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/bootstrap/pom.xml b/bootstrap/pom.xml
-index 1c614e03..40c5073d 100644
+index 517e103f..9a8cec20 100644
 --- a/bootstrap/pom.xml
 +++ b/bootstrap/pom.xml
 @@ -4,39 +4,40 @@
@@ -78,7 +78,7 @@ index 1c614e03..40c5073d 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -86,7 +86,7 @@ index 1c614e03..40c5073d 100644
 -    <artifactId>bungeecord-bootstrap</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-bootstrap</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Bootstrap</name>
@@ -145,7 +145,7 @@ index 6be22739..a4516ed9 100644
              return;
          }
 diff --git a/chat/pom.xml b/chat/pom.xml
-index 03de91ed..586ea984 100644
+index 102c2121..6acd757d 100644
 --- a/chat/pom.xml
 +++ b/chat/pom.xml
 @@ -4,19 +4,19 @@
@@ -156,7 +156,7 @@ index 03de91ed..586ea984 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -164,7 +164,7 @@ index 03de91ed..586ea984 100644
 -    <artifactId>bungeecord-chat</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-chat</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Chat</name>
@@ -175,7 +175,7 @@ index 03de91ed..586ea984 100644
      <dependencies>
          <dependency>
 diff --git a/config/pom.xml b/config/pom.xml
-index 375f686e..ec4481ff 100644
+index b24fb9d3..7041e584 100644
 --- a/config/pom.xml
 +++ b/config/pom.xml
 @@ -4,19 +4,19 @@
@@ -186,7 +186,7 @@ index 375f686e..ec4481ff 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -194,7 +194,7 @@ index 375f686e..ec4481ff 100644
 -    <artifactId>bungeecord-config</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-config</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Config</name>
@@ -205,7 +205,7 @@ index 375f686e..ec4481ff 100644
      <dependencies>
          <dependency>
 diff --git a/event/pom.xml b/event/pom.xml
-index 7d4754f5..759bd9f1 100644
+index 61ee9b45..eab7e89d 100644
 --- a/event/pom.xml
 +++ b/event/pom.xml
 @@ -4,17 +4,17 @@
@@ -216,7 +216,7 @@ index 7d4754f5..759bd9f1 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -224,7 +224,7 @@ index 7d4754f5..759bd9f1 100644
 -    <artifactId>bungeecord-event</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-event</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Event</name>
@@ -233,7 +233,7 @@ index 7d4754f5..759bd9f1 100644
 +    <description>Generic java event dispatching API intended for use with Waterfall.</description>
  </project>
 diff --git a/log/pom.xml b/log/pom.xml
-index 0a7f58c5..7601bd91 100644
+index 37679ec1..e694ea92 100644
 --- a/log/pom.xml
 +++ b/log/pom.xml
 @@ -4,19 +4,19 @@
@@ -244,7 +244,7 @@ index 0a7f58c5..7601bd91 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -252,7 +252,7 @@ index 0a7f58c5..7601bd91 100644
 -    <artifactId>bungeecord-log</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-log</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Log</name>
@@ -274,7 +274,7 @@ index 0a7f58c5..7601bd91 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/module/cmd-alert/pom.xml b/module/cmd-alert/pom.xml
-index fa9df0ef..6389a5dc 100644
+index 13676182..fc3f961a 100644
 --- a/module/cmd-alert/pom.xml
 +++ b/module/cmd-alert/pom.xml
 @@ -4,14 +4,14 @@
@@ -285,7 +285,7 @@ index fa9df0ef..6389a5dc 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -293,11 +293,11 @@ index fa9df0ef..6389a5dc 100644
 -    <artifactId>bungeecord-module-cmd-alert</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-alert</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-find/pom.xml b/module/cmd-find/pom.xml
-index 5b021da4..4df6d3d7 100644
+index 631101b4..0decccbf 100644
 --- a/module/cmd-find/pom.xml
 +++ b/module/cmd-find/pom.xml
 @@ -4,14 +4,14 @@
@@ -308,7 +308,7 @@ index 5b021da4..4df6d3d7 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -316,11 +316,11 @@ index 5b021da4..4df6d3d7 100644
 -    <artifactId>bungeecord-module-cmd-find</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-find</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-kick/pom.xml b/module/cmd-kick/pom.xml
-index 661384ce..9185e77d 100644
+index 63f5b26e..9ee5d12b 100644
 --- a/module/cmd-kick/pom.xml
 +++ b/module/cmd-kick/pom.xml
 @@ -4,14 +4,14 @@
@@ -331,7 +331,7 @@ index 661384ce..9185e77d 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -339,11 +339,11 @@ index 661384ce..9185e77d 100644
 -    <artifactId>bungeecord-module-cmd-kick</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-kick</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-list/pom.xml b/module/cmd-list/pom.xml
-index b5ed3e23..c0c5eba4 100644
+index 8c33b885..6e28000c 100644
 --- a/module/cmd-list/pom.xml
 +++ b/module/cmd-list/pom.xml
 @@ -4,14 +4,14 @@
@@ -354,7 +354,7 @@ index b5ed3e23..c0c5eba4 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -362,11 +362,11 @@ index b5ed3e23..c0c5eba4 100644
 -    <artifactId>bungeecord-module-cmd-list</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-list</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-send/pom.xml b/module/cmd-send/pom.xml
-index 81d888dd..06d9d89a 100644
+index 789dff3f..fe58ddd5 100644
 --- a/module/cmd-send/pom.xml
 +++ b/module/cmd-send/pom.xml
 @@ -4,14 +4,14 @@
@@ -377,7 +377,7 @@ index 81d888dd..06d9d89a 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -385,11 +385,11 @@ index 81d888dd..06d9d89a 100644
 -    <artifactId>bungeecord-module-cmd-send</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-send</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/cmd-server/pom.xml b/module/cmd-server/pom.xml
-index b39740a4..90e4f5e0 100644
+index 030b2290..2fd7406a 100644
 --- a/module/cmd-server/pom.xml
 +++ b/module/cmd-server/pom.xml
 @@ -4,14 +4,14 @@
@@ -400,7 +400,7 @@ index b39740a4..90e4f5e0 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -408,11 +408,11 @@ index b39740a4..90e4f5e0 100644
 -    <artifactId>bungeecord-module-cmd-server</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-cmd-server</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/module/pom.xml b/module/pom.xml
-index 67ed4450..d6000bc8 100644
+index 762fc89d..bba9d876 100644
 --- a/module/pom.xml
 +++ b/module/pom.xml
 @@ -4,19 +4,19 @@
@@ -423,7 +423,7 @@ index 67ed4450..d6000bc8 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -431,7 +431,7 @@ index 67ed4450..d6000bc8 100644
 -    <artifactId>bungeecord-module</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>pom</packaging>
  
 -    <name>BungeeCord Modules</name>
@@ -461,7 +461,7 @@ index 67ed4450..d6000bc8 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/module/reconnect-yaml/pom.xml b/module/reconnect-yaml/pom.xml
-index d0b2f530..364797ae 100644
+index 14897894..0510cf5f 100644
 --- a/module/reconnect-yaml/pom.xml
 +++ b/module/reconnect-yaml/pom.xml
 @@ -4,14 +4,14 @@
@@ -472,7 +472,7 @@ index d0b2f530..364797ae 100644
 -        <artifactId>bungeecord-module</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-module</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -480,11 +480,11 @@ index d0b2f530..364797ae 100644
 -    <artifactId>bungeecord-module-reconnect-yaml</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-module-reconnect-yaml</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 diff --git a/native/pom.xml b/native/pom.xml
-index b81769ce..eba83749 100644
+index f87a1bea..cee9d672 100644
 --- a/native/pom.xml
 +++ b/native/pom.xml
 @@ -4,19 +4,19 @@
@@ -495,7 +495,7 @@ index b81769ce..eba83749 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -503,7 +503,7 @@ index b81769ce..eba83749 100644
 -    <artifactId>bungeecord-native</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-native</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Native</name>
@@ -514,7 +514,7 @@ index b81769ce..eba83749 100644
      <dependencies>
          <dependency>
 diff --git a/pom.xml b/pom.xml
-index e203e519..454eb788 100644
+index 0af145e1..e1da472e 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,18 +3,18 @@
@@ -525,7 +525,7 @@ index e203e519..454eb788 100644
 -    <artifactId>bungeecord-parent</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-parent</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>pom</packaging>
  
 -    <name>BungeeCord-Parent</name>
@@ -659,7 +659,7 @@ index e203e519..454eb788 100644
                              </execution>
                          </executions>
 diff --git a/protocol/pom.xml b/protocol/pom.xml
-index 702f8e7b..16351bad 100644
+index 10278395..85e66f0c 100644
 --- a/protocol/pom.xml
 +++ b/protocol/pom.xml
 @@ -4,19 +4,19 @@
@@ -670,7 +670,7 @@ index 702f8e7b..16351bad 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -678,7 +678,7 @@ index 702f8e7b..16351bad 100644
 -    <artifactId>bungeecord-protocol</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-protocol</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Protocol</name>
@@ -700,7 +700,7 @@ index 702f8e7b..16351bad 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index 587b7bdb..5f57b218 100644
+index fdb3a2f0..7f75b8b1 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
 @@ -4,18 +4,18 @@
@@ -711,7 +711,7 @@ index 587b7bdb..5f57b218 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -719,7 +719,7 @@ index 587b7bdb..5f57b218 100644
 -    <artifactId>bungeecord-proxy</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-proxy</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Proxy</name>
@@ -728,7 +728,7 @@ index 587b7bdb..5f57b218 100644
  
      <properties>
 @@ -64,38 +64,38 @@
-             <classifier>linux-aarch_64</classifier>
+             <scope>compile</scope>
          </dependency>
          <dependency>
 -            <groupId>net.md-5</groupId>
@@ -779,7 +779,7 @@ index 587b7bdb..5f57b218 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/query/pom.xml b/query/pom.xml
-index 239cd735..230741c0 100644
+index f86003fb..dd4b2460 100644
 --- a/query/pom.xml
 +++ b/query/pom.xml
 @@ -4,19 +4,19 @@
@@ -790,7 +790,7 @@ index 239cd735..230741c0 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -798,7 +798,7 @@ index 239cd735..230741c0 100644
 -    <artifactId>bungeecord-query</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-query</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-Query</name>
@@ -820,7 +820,7 @@ index 239cd735..230741c0 100644
              <scope>compile</scope>
          </dependency>
 diff --git a/slf4j/pom.xml b/slf4j/pom.xml
-index a9617a79..f5f74431 100644
+index 68ba54d4..c6112807 100644
 --- a/slf4j/pom.xml
 +++ b/slf4j/pom.xml
 @@ -4,18 +4,18 @@
@@ -831,7 +831,7 @@ index a9617a79..f5f74431 100644
 -        <artifactId>bungeecord-parent</artifactId>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-         <version>1.21-R0.2-SNAPSHOT</version>
+         <version>1.21-R0.3-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
  
@@ -839,7 +839,7 @@ index a9617a79..f5f74431 100644
 -    <artifactId>bungeecord-slf4j</artifactId>
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-slf4j</artifactId>
-     <version>1.21-R0.2-SNAPSHOT</version>
+     <version>1.21-R0.3-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>BungeeCord-SLF4J</name>
@@ -848,5 +848,5 @@ index a9617a79..f5f74431 100644
  
      <properties>
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0003-Rename-references-from-BungeeCord-to-Waterfall.patch
+++ b/BungeeCord-Patches/0003-Rename-references-from-BungeeCord-to-Waterfall.patch
@@ -1,4 +1,4 @@
-From a74c6e19ba9a59288d6cf7fb9c387b2309371862 Mon Sep 17 00:00:00 2001
+From 8f814574c1555cad66d18481113949259ff7cf9f Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Thu, 19 May 2016 11:28:45 -0700
 Subject: [PATCH] Rename references from BungeeCord to Waterfall
@@ -18,10 +18,10 @@ index f1ccd4f6..d703d6d2 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index c39239bc..37aeae0c 100644
+index 849662a7..8f03f72f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -208,7 +208,7 @@ public class BungeeCord extends ProxyServer
+@@ -182,7 +182,7 @@ public class BungeeCord extends ProxyServer
      public BungeeCord() throws IOException
      {
          // Java uses ! to indicate a resource inside of a jar/zip/other container. Running Bungee from within a directory that has a ! will cause this to muck up.
@@ -30,7 +30,7 @@ index c39239bc..37aeae0c 100644
  
          reloadMessages();
  
-@@ -557,7 +557,7 @@ public class BungeeCord extends ProxyServer
+@@ -531,7 +531,7 @@ public class BungeeCord extends ProxyServer
      @Override
      public String getName()
      {
@@ -101,5 +101,5 @@ index 95781e33..18ecdee1 100644
              SocketAddress address = Util.getAddr( addr );
              ServerInfo info = ProxyServer.getInstance().constructServerInfo( name, address, motd, restricted );
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0004-Add-Waterfall-configuration-files.patch
+++ b/BungeeCord-Patches/0004-Add-Waterfall-configuration-files.patch
@@ -1,4 +1,4 @@
-From 170b6d6aeb2eb69e636310e0f47c0025de82dac5 Mon Sep 17 00:00:00 2001
+From 30a378c7bfb8a741f14309a4777219d89152d1f9 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 25 Oct 2016 11:58:37 -0400
 Subject: [PATCH] Add Waterfall configuration files
@@ -42,18 +42,18 @@ index 00000000..741ebfde
 +
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 37aeae0c..98203cc8 100644
+index 8f03f72f..6a337941 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -9,6 +9,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
- import com.google.gson.Gson;
- import com.google.gson.GsonBuilder;
+@@ -7,6 +7,7 @@ import com.google.common.collect.Lists;
+ import com.google.common.collect.Sets;
+ import com.google.common.util.concurrent.ThreadFactoryBuilder;
  import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 +import io.github.waterfallmc.waterfall.conf.WaterfallConfiguration;
  import io.netty.bootstrap.ServerBootstrap;
  import io.netty.channel.Channel;
  import io.netty.channel.ChannelException;
-@@ -117,7 +118,7 @@ public class BungeeCord extends ProxyServer
+@@ -101,7 +102,7 @@ public class BungeeCord extends ProxyServer
       * Configuration.
       */
      @Getter
@@ -76,7 +76,7 @@ index 95320050..2c819684 100644
  
      /**
 diff --git a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
-index 3f2c82b2..1de9875c 100644
+index 18ecdee1..915cfeda 100644
 --- a/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
 +++ b/proxy/src/main/java/net/md_5/bungee/conf/YamlConfig.java
 @@ -47,10 +47,15 @@ public class YamlConfig implements ConfigurationAdapter
@@ -118,5 +118,5 @@ index 3f2c82b2..1de9875c 100644
          if ( permissions == null )
          {
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0005-Disable-Metrics.patch
+++ b/BungeeCord-Patches/0005-Disable-Metrics.patch
@@ -1,4 +1,4 @@
-From aaaf0b95e6554567d0c7d033961e82b0f6783247 Mon Sep 17 00:00:00 2001
+From a28b575469ed47df19de1e4e794360475aa70c5e Mon Sep 17 00:00:00 2001
 From: Jamie Mansfield <dev@jamierocks.uk>
 Date: Thu, 19 May 2016 10:55:20 -0700
 Subject: [PATCH] Disable Metrics
@@ -6,10 +6,10 @@ Subject: [PATCH] Disable Metrics
 MCStats has not been stable for a long while now, and in our opinion it is not worth migrating to an alternative service. Waterfall has been maintained for the past two years without any or much consideration to statistics, we have users and that's enough for us ;)
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 98203cc8..7ad603af 100644
+index 6a337941..62febfd1 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -128,7 +128,7 @@ public class BungeeCord extends ProxyServer
+@@ -112,7 +112,7 @@ public class BungeeCord extends ProxyServer
       * locations.yml save thread.
       */
      private final Timer saveThread = new Timer( "Reconnect Saver" );
@@ -18,7 +18,7 @@ index 98203cc8..7ad603af 100644
      /**
       * Server socket listener.
       */
-@@ -331,7 +331,7 @@ public class BungeeCord extends ProxyServer
+@@ -305,7 +305,7 @@ public class BungeeCord extends ProxyServer
                  }
              }
          }, 0, TimeUnit.MINUTES.toMillis( 5 ) );
@@ -27,7 +27,7 @@ index 98203cc8..7ad603af 100644
  
          Runtime.getRuntime().addShutdownHook( new Thread()
          {
-@@ -489,7 +489,7 @@ public class BungeeCord extends ProxyServer
+@@ -463,7 +463,7 @@ public class BungeeCord extends ProxyServer
              reconnectHandler.close();
          }
          saveThread.cancel();
@@ -177,5 +177,5 @@ index eabf7573..00000000
 -    }
 -}
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
+++ b/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
@@ -1,4 +1,4 @@
-From e039f5f1fe9b20ef4c6946b2ce0b1bc55ea232a0 Mon Sep 17 00:00:00 2001
+From 29b9c5ae16cc50d746f8552df16a21b736fa9461 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 3 May 2016 20:31:52 -0700
 Subject: [PATCH] Don't access a ByteBuf's underlying array
@@ -45,10 +45,10 @@ index 1a7d8512..ad1704dd 100644
       * Allow this packet to be sent as an "extended" packet.
       */
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 8f52c50e..33c2c8ab 100644
+index 5583a1b3..3cd625b9 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -287,7 +287,7 @@ public class ServerConnector extends PacketHandler
+@@ -286,7 +286,7 @@ public class ServerConnector extends PacketHandler
  
                  ByteBuf brand = ByteBufAllocator.DEFAULT.heapBuffer();
                  DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")", brand );
@@ -58,10 +58,10 @@ index 8f52c50e..33c2c8ab 100644
              }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 64e9a764..f5b3f7a8 100644
+index 10f7ba99..9113a3fa 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -328,7 +328,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -327,7 +327,7 @@ public class DownstreamBridge extends PacketHandler
  
              brand = ByteBufAllocator.DEFAULT.heapBuffer();
              DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")" + " <- " + serverBrand, brand );
@@ -71,10 +71,10 @@ index 64e9a764..f5b3f7a8 100644
              // changes in the packet are ignored so we need to send it manually
              con.unsafe().sendPacket( pluginMessage );
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index d9536149..9b7c15e1 100644
+index 21664e76..4b41d61f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-@@ -56,7 +56,7 @@ import net.md_5.bungee.util.PacketLimiter;
+@@ -57,7 +57,7 @@ import net.md_5.bungee.util.PacketLimiter;
  public class PipelineUtils
  {
  
@@ -84,5 +84,5 @@ index d9536149..9b7c15e1 100644
      private static void setChannelInitializerHolders()
      {
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
+++ b/BungeeCord-Patches/0009-Don-t-access-a-ByteBuf-s-underlying-array.patch
@@ -1,4 +1,4 @@
-From 29b9c5ae16cc50d746f8552df16a21b736fa9461 Mon Sep 17 00:00:00 2001
+From 2e82da30be2b841a49b88611772048d9b3bdb351 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Tue, 3 May 2016 20:31:52 -0700
 Subject: [PATCH] Don't access a ByteBuf's underlying array
@@ -58,10 +58,10 @@ index 5583a1b3..3cd625b9 100644
              }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 10f7ba99..9113a3fa 100644
+index 71470345..32cd0219 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -327,7 +327,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -328,7 +328,7 @@ public class DownstreamBridge extends PacketHandler
  
              brand = ByteBufAllocator.DEFAULT.heapBuffer();
              DefinedPacket.writeString( bungee.getName() + " (" + bungee.getVersion() + ")" + " <- " + serverBrand, brand );

--- a/BungeeCord-Patches/0010-Optimize-uuid-conversions.patch
+++ b/BungeeCord-Patches/0010-Optimize-uuid-conversions.patch
@@ -1,4 +1,4 @@
-From 4674760b916deb68fb27d17c65ed583e805fde26 Mon Sep 17 00:00:00 2001
+From 0e1022f1e1c7d0194a46f1942c9b9d0ff5515712 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Mon, 14 Mar 2016 15:40:44 -0700
 Subject: [PATCH] Optimize uuid conversions
@@ -250,10 +250,10 @@ index e582808f..29cd91dd 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index e4c92ef7..e684ba09 100644
+index fa1f2bef..cba35899 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -797,7 +797,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -800,7 +800,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      @Override
      public String getUUID()
      {

--- a/BungeeCord-Patches/0010-Optimize-uuid-conversions.patch
+++ b/BungeeCord-Patches/0010-Optimize-uuid-conversions.patch
@@ -1,4 +1,4 @@
-From 76d5811ff1c891c4f93863f8a78ed8c60312065b Mon Sep 17 00:00:00 2001
+From 4674760b916deb68fb27d17c65ed583e805fde26 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Mon, 14 Mar 2016 15:40:44 -0700
 Subject: [PATCH] Optimize uuid conversions
@@ -250,10 +250,10 @@ index e582808f..29cd91dd 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index a048d5a3..1e3aef58 100644
+index e4c92ef7..e684ba09 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -798,7 +798,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -797,7 +797,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      @Override
      public String getUUID()
      {
@@ -263,5 +263,5 @@ index a048d5a3..1e3aef58 100644
  
      @Override
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch
+++ b/BungeeCord-Patches/0011-Add-support-for-FML-with-IP-Forwarding-enabled.patch
@@ -1,4 +1,4 @@
-From a6ab00d6508517ec350839b3daac9ec62ede5a58 Mon Sep 17 00:00:00 2001
+From b26d92d12ecd1b8bf2692e93d4e665d2c6256647 Mon Sep 17 00:00:00 2001
 From: Daniel Naylor <git@drnaylor.co.uk>
 Date: Tue, 25 Oct 2016 12:23:07 -0400
 Subject: [PATCH] Add support for FML with IP Forwarding enabled
@@ -12,7 +12,7 @@ However, there is now at least one Forge coremod that intends to support IP forw
 No breaking changes occur due to this patch.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 33c2c8ab..86b4b8ed 100644
+index 3cd625b9..c0487684 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -7,6 +7,7 @@ import io.netty.buffer.ByteBufAllocator;
@@ -23,7 +23,7 @@ index 33c2c8ab..86b4b8ed 100644
  import java.util.Queue;
  import java.util.Set;
  import java.util.UUID;
-@@ -116,15 +117,39 @@ public class ServerConnector extends PacketHandler
+@@ -115,15 +116,39 @@ public class ServerConnector extends PacketHandler
              String newHost = copiedHandshake.getHost() + "\00" + AddressUtil.sanitizeAddress( user.getAddress() ) + "\00" + user.getUUID();
  
              LoginResult profile = user.getPendingConnection().getLoginProfile();
@@ -33,7 +33,7 @@ index 33c2c8ab..86b4b8ed 100644
 +
              if ( profile != null && profile.getProperties() != null && profile.getProperties().length > 0 )
              {
--                newHost += "\00" + BungeeCord.getInstance().gson.toJson( profile.getProperties() );
+-                newHost += "\00" + LoginResult.GSON.toJson( profile.getProperties() );
 +                properties = profile.getProperties();
              }
 +
@@ -54,7 +54,7 @@ index 33c2c8ab..86b4b8ed 100644
 +
 +            // If we touched any properties, then append them
 +            if (properties.length > 0) {
-+                newHost += "\00" + BungeeCord.getInstance().gson.toJson(properties);
++                newHost += "\00" + LoginResult.GSON.toJson(properties);
 +            }
 +
              copiedHandshake.setHost( newHost );
@@ -67,10 +67,10 @@ index 33c2c8ab..86b4b8ed 100644
          }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 74ca0ac4..1dc6be5d 100644
+index 84ca1eae..6287c3fc 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -181,9 +181,12 @@ public final class UserConnection implements ProxiedPlayer
+@@ -185,9 +185,12 @@ public final class UserConnection implements ProxiedPlayer
  
          forgeClientHandler = new ForgeClientHandler( this );
  
@@ -101,5 +101,5 @@ index 6dca2048..f5253b89 100644
       * The FML 1.8 handshake token.
       */
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0014-Enable-TCP_NODELAY.patch
+++ b/BungeeCord-Patches/0014-Enable-TCP_NODELAY.patch
@@ -1,4 +1,4 @@
-From 7abc80e5eaca9e53461e4db11df77f850ed80973 Mon Sep 17 00:00:00 2001
+From d5094e0f3cfd54e759a19a2c76a25790d79e8e5d Mon Sep 17 00:00:00 2001
 From: Harry <me@harry5573.uk>
 Date: Sun, 24 Jan 2016 15:13:29 -0700
 Subject: [PATCH] Enable TCP_NODELAY.
@@ -6,17 +6,17 @@ Subject: [PATCH] Enable TCP_NODELAY.
 This is enabled by default on CraftBukkit/Spigot >= 1.8 and may help with network performance.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index 9b7c15e1..77a458cc 100644
+index 4b41d61f..a6d1b287 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-@@ -217,6 +217,7 @@ public class PipelineUtils
-             {
-                 // IP_TOS is not supported (Windows XP / Windows Server 2003)
+@@ -221,6 +221,7 @@ public class PipelineUtils
              }
+             // https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide
+             // TODO: check for AdaptiveByteBufAllocator
 +            ch.config().setOption( ChannelOption.TCP_NODELAY, true );
              ch.config().setAllocator( PooledByteBufAllocator.DEFAULT );
              ch.config().setWriteBufferWaterMark( MARK );
  
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0015-Micro-optimizations.patch
+++ b/BungeeCord-Patches/0015-Micro-optimizations.patch
@@ -1,4 +1,4 @@
-From 3b45c584532a46595650c4301886244022b185de Mon Sep 17 00:00:00 2001
+From bc7defd853a8c80a3d959606109eb41ea805c4e8 Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Tue, 19 Jan 2016 15:13:29 -0700
 Subject: [PATCH] Micro-optimizations
@@ -8,10 +8,10 @@ Subject: [PATCH] Micro-optimizations
 - Don't create a data input stream for every plugin message we get from servers
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 9113a3fa..682e33be 100644
+index 32cd0219..30664771 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -309,7 +309,6 @@ public class DownstreamBridge extends PacketHandler
+@@ -310,7 +310,6 @@ public class DownstreamBridge extends PacketHandler
      @SuppressWarnings("checkstyle:avoidnestedblocks")
      public void handle(PluginMessage pluginMessage) throws Exception
      {
@@ -19,7 +19,7 @@ index 9113a3fa..682e33be 100644
          PluginMessageEvent event = new PluginMessageEvent( server, con, pluginMessage.getTag(), pluginMessage.getData().clone() );
  
          if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
-@@ -336,6 +335,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -337,6 +336,7 @@ public class DownstreamBridge extends PacketHandler
  
          if ( pluginMessage.getTag().equals( PluginMessage.BUNGEE_CHANNEL_LEGACY ) )
          {

--- a/BungeeCord-Patches/0015-Micro-optimizations.patch
+++ b/BungeeCord-Patches/0015-Micro-optimizations.patch
@@ -1,4 +1,4 @@
-From c5f080e880e2fef9a8f4b405f669acd11b603e62 Mon Sep 17 00:00:00 2001
+From 3b45c584532a46595650c4301886244022b185de Mon Sep 17 00:00:00 2001
 From: Tux <write@imaginarycode.com>
 Date: Tue, 19 Jan 2016 15:13:29 -0700
 Subject: [PATCH] Micro-optimizations
@@ -8,10 +8,10 @@ Subject: [PATCH] Micro-optimizations
 - Don't create a data input stream for every plugin message we get from servers
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index f5b3f7a8..137d949e 100644
+index 9113a3fa..682e33be 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -310,7 +310,6 @@ public class DownstreamBridge extends PacketHandler
+@@ -309,7 +309,6 @@ public class DownstreamBridge extends PacketHandler
      @SuppressWarnings("checkstyle:avoidnestedblocks")
      public void handle(PluginMessage pluginMessage) throws Exception
      {
@@ -19,7 +19,7 @@ index f5b3f7a8..137d949e 100644
          PluginMessageEvent event = new PluginMessageEvent( server, con, pluginMessage.getTag(), pluginMessage.getData().clone() );
  
          if ( bungee.getPluginManager().callEvent( event ).isCancelled() )
-@@ -337,6 +336,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -336,6 +335,7 @@ public class DownstreamBridge extends PacketHandler
  
          if ( pluginMessage.getTag().equals( PluginMessage.BUNGEE_CHANNEL_LEGACY ) )
          {
@@ -28,5 +28,5 @@ index f5b3f7a8..137d949e 100644
              String subChannel = in.readUTF();
  
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From caf1b27027c4eb875155e55696002d7fde32b7f0 Mon Sep 17 00:00:00 2001
+From 625b7cdf886ab66523854253f2292ea3c9784665 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -9,25 +9,28 @@ Vanilla servers still error on negative/invalid packets.
 Original issue: https://github.com/WaterfallMC/Waterfall-Old/issues/11
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index d79d5e5c..250e7620 100644
+index abcb53bb..1c21a330 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-@@ -18,6 +18,14 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
-     private final boolean server;
+@@ -14,7 +14,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+ 
+     public MinecraftDecoder(Protocol protocol, boolean server, int protocolVersion)
+     {
+-        this( protocol, server, protocolVersion, shouldCopyBuffer( protocol, protocolVersion ) );
++        this( protocol, server, protocolVersion, shouldCopyBuffer( protocol, protocolVersion ), false );
+     }
+ 
+     @Getter
+@@ -23,6 +23,8 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
      @Setter
      private int protocolVersion;
+     private boolean copyBuffer;
 +    @Setter
 +    private boolean supportsForge = false;
-+
-+    public MinecraftDecoder(Protocol protocol, boolean server, int protocolVersion) {
-+        this.protocol = protocol;
-+        this.server = server;
-+        this.protocolVersion = protocolVersion;
-+    }
  
      @Override
      protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception
-@@ -36,7 +44,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -40,7 +42,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
          {
              int packetId = DefinedPacket.readVarInt( in );
  
@@ -83,10 +86,10 @@ index c0487684..2b9487dc 100644
  
          ch.write( BungeeCord.getInstance().registerChannels( user.getPendingConnection().getVersion() ) );
 diff --git a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-index c8fdb2e9..1bf73fd2 100644
+index eab5a947..1a27d786 100644
 --- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 +++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-@@ -349,6 +349,12 @@ public abstract class EntityMap
+@@ -337,6 +337,12 @@ public abstract class EntityMap
          int packetId = DefinedPacket.readVarInt( packet );
          int packetIdLength = packet.readerIndex() - readerIndex;
  

--- a/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
+++ b/BungeeCord-Patches/0016-Allow-invalid-packet-ids-for-forge-servers.patch
@@ -1,4 +1,4 @@
-From d4f939d0362bfedb493701c2e60355a08d8004f3 Mon Sep 17 00:00:00 2001
+From caf1b27027c4eb875155e55696002d7fde32b7f0 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 19 May 2016 17:09:22 -0600
 Subject: [PATCH] Allow invalid packet ids for forge servers
@@ -66,10 +66,10 @@ index 40fdb868..34be8c00 100644
                  throw new BadPacketException( "Packet with id " + id + " outside of range" );
              }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 86b4b8ed..1af6d465 100644
+index c0487684..2b9487dc 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -244,6 +244,12 @@ public class ServerConnector extends PacketHandler
+@@ -243,6 +243,12 @@ public class ServerConnector extends PacketHandler
      public static void handleLogin(ProxyServer bungee, ChannelWrapper ch, UserConnection user, BungeeServerInfo target, ForgeServerHandler handshakeHandler, ServerConnection server, Login login) throws Exception
      {
          ServerConnectedEvent event = new ServerConnectedEvent( user, server );
@@ -100,5 +100,5 @@ index c8fdb2e9..1bf73fd2 100644
          {
              rewriteInt( packet, oldId, newId, readerIndex + packetIdLength );
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0017-Add-basic-support-for-configurable-tab-complete-thro.patch
+++ b/BungeeCord-Patches/0017-Add-basic-support-for-configurable-tab-complete-thro.patch
@@ -1,4 +1,4 @@
-From 7c3811f556c096bb26e777ee55bc51ee87d1cbd9 Mon Sep 17 00:00:00 2001
+From 67afd179c1a84dd0d4bca0f7bf9bf693ddef1f65 Mon Sep 17 00:00:00 2001
 From: Johannes Donath <johannesd@torchmind.com>
 Date: Sat, 4 Jul 2015 06:31:33 +0200
 Subject: [PATCH] Add basic support for configurable tab-complete throttling
@@ -73,10 +73,10 @@ index 741ebfde..91743f01 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 49967de9..0961c6e6 100644
+index 93f57bc1..18e5065e 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -52,6 +52,8 @@ public class UpstreamBridge extends PacketHandler
+@@ -51,6 +51,8 @@ public class UpstreamBridge extends PacketHandler
      private final ProxyServer bungee;
      private final UserConnection con;
  
@@ -85,7 +85,7 @@ index 49967de9..0961c6e6 100644
      public UpstreamBridge(ProxyServer bungee, UserConnection con)
      {
          this.bungee = bungee;
-@@ -232,6 +234,20 @@ public class UpstreamBridge extends PacketHandler
+@@ -231,6 +233,20 @@ public class UpstreamBridge extends PacketHandler
      @Override
      public void handle(TabCompleteRequest tabComplete) throws Exception
      {
@@ -107,5 +107,5 @@ index 49967de9..0961c6e6 100644
          boolean isRegisteredCommand = false;
          boolean isCommand = tabComplete.getCursor().startsWith( "/" );
 -- 
-2.47.1
+2.43.0
 

--- a/BungeeCord-Patches/0018-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0018-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From b79c04a891cdd4371e94fca186e69d825a5b8f82 Mon Sep 17 00:00:00 2001
+From e8070eab3ab332dff637eb56b172f4cdabaece6f Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -19,10 +19,10 @@ index 2b9487dc..26abaa80 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 682e33be..ea693300 100644
+index 30664771..080ca279 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -804,6 +804,6 @@ public class DownstreamBridge extends PacketHandler
+@@ -815,6 +815,6 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public String toString()
      {
@@ -31,10 +31,10 @@ index 682e33be..ea693300 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index e684ba09..7283ff26 100644
+index cba35899..70850b4f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -803,20 +803,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -806,20 +806,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      @Override
      public String toString()
      {
@@ -57,10 +57,10 @@ index e684ba09..7283ff26 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index 580b4d70..a6176702 100644
+index 18e5065e..459aff6d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -404,6 +404,6 @@ public class UpstreamBridge extends PacketHandler
+@@ -397,6 +397,6 @@ public class UpstreamBridge extends PacketHandler
      @Override
      public String toString()
      {

--- a/BungeeCord-Patches/0018-Improve-server-list-ping-logging.patch
+++ b/BungeeCord-Patches/0018-Improve-server-list-ping-logging.patch
@@ -1,4 +1,4 @@
-From 6a08ec5a29e307665e5f3f8fd95a3237fd0fd7fa Mon Sep 17 00:00:00 2001
+From b79c04a891cdd4371e94fca186e69d825a5b8f82 Mon Sep 17 00:00:00 2001
 From: Janmm14 <computerjanimaus@yahoo.de>
 Date: Sat, 12 Dec 2015 23:43:30 +0100
 Subject: [PATCH] Improve server list ping logging
@@ -7,10 +7,10 @@ This functionality of this patch was adopted upstream, however, this
 patch remains for a few misc improvements around here
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 1af6d465..38e06e4c 100644
+index 2b9487dc..26abaa80 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -534,6 +534,6 @@ public class ServerConnector extends PacketHandler
+@@ -533,6 +533,6 @@ public class ServerConnector extends PacketHandler
      @Override
      public String toString()
      {
@@ -19,10 +19,10 @@ index 1af6d465..38e06e4c 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 137d949e..3c286239 100644
+index 682e33be..ea693300 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -805,6 +805,6 @@ public class DownstreamBridge extends PacketHandler
+@@ -804,6 +804,6 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public String toString()
      {
@@ -31,10 +31,10 @@ index 137d949e..3c286239 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 1e3aef58..13889ced 100644
+index e684ba09..7283ff26 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -804,20 +804,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -803,20 +803,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      @Override
      public String toString()
      {
@@ -57,7 +57,7 @@ index 1e3aef58..13889ced 100644
  
      @Override
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index e7d46d53..ba0ef69d 100644
+index 580b4d70..a6176702 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 @@ -404,6 +404,6 @@ public class UpstreamBridge extends PacketHandler
@@ -69,5 +69,5 @@ index e7d46d53..ba0ef69d 100644
      }
  }
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0019-Add-a-property-to-accept-invalid-ping-packets.patch
+++ b/BungeeCord-Patches/0019-Add-a-property-to-accept-invalid-ping-packets.patch
@@ -1,4 +1,4 @@
-From 32957156db178745864b7da27f459646501f5790 Mon Sep 17 00:00:00 2001
+From d1cdc6d9c5cfba536b694f6596100c850f0a9df3 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Sun, 7 Feb 2016 00:01:19 -0700
 Subject: [PATCH] Add a property to accept invalid ping packets
@@ -9,10 +9,10 @@ You can enable it by setting '-Dwaterfall.acceptInvalidPackets=true' at the comm
 Fixes #23
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 7283ff26..041c3103 100644
+index 70850b4f..217030d2 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -324,10 +324,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -327,10 +327,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          }
      }
  

--- a/BungeeCord-Patches/0019-Add-a-property-to-accept-invalid-ping-packets.patch
+++ b/BungeeCord-Patches/0019-Add-a-property-to-accept-invalid-ping-packets.patch
@@ -1,4 +1,4 @@
-From bc9ade8f2367594c2a006eed753e0621f7930c8f Mon Sep 17 00:00:00 2001
+From 32957156db178745864b7da27f459646501f5790 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Sun, 7 Feb 2016 00:01:19 -0700
 Subject: [PATCH] Add a property to accept invalid ping packets
@@ -9,11 +9,11 @@ You can enable it by setting '-Dwaterfall.acceptInvalidPackets=true' at the comm
 Fixes #23
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 13889ced..c86121d5 100644
+index 7283ff26..041c3103 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -329,10 +329,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
-         thisState = State.PING;
+@@ -324,10 +324,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+         }
      }
  
 +    private static final boolean ACCEPT_INVALID_PACKETS = Boolean.parseBoolean(System.getProperty("waterfall.acceptInvalidPackets", "false"));
@@ -27,7 +27,7 @@ index 13889ced..c86121d5 100644
 +        }
          unsafe.sendPacket( ping );
          disconnect( "" );
-     }
+         if ( bungee.getConnectionThrottle() != null )
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0020-Use-a-worker-and-a-boss-event-loop-group.patch
+++ b/BungeeCord-Patches/0020-Use-a-worker-and-a-boss-event-loop-group.patch
@@ -1,4 +1,4 @@
-From 92e0203e14b843b19ce4f98ebb7551051fddbb20 Mon Sep 17 00:00:00 2001
+From 1579c4e6ee9ebaa58fde2027a9111881f2773a38 Mon Sep 17 00:00:00 2001
 From: kamcio96 <k.nadworski@icloud.com>
 Date: Mon, 14 Mar 2016 16:07:20 -0700
 Subject: [PATCH] Use a worker and a boss event loop group.
@@ -8,10 +8,10 @@ Merges the rest of https://github.com/SpigotMC/BungeeCord/pull/1706 by @kamcio96
 This is proper practice for netty.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 7ad603af..33390578 100644
+index 62febfd1..7fd69a3f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -123,7 +123,7 @@ public class BungeeCord extends ProxyServer
+@@ -107,7 +107,7 @@ public class BungeeCord extends ProxyServer
       * Localization formats.
       */
      private Map<String, Format> messageFormats;
@@ -20,7 +20,7 @@ index 7ad603af..33390578 100644
      /**
       * locations.yml save thread.
       */
-@@ -289,7 +289,8 @@ public class BungeeCord extends ProxyServer
+@@ -263,7 +263,8 @@ public class BungeeCord extends ProxyServer
              ResourceLeakDetector.setLevel( ResourceLeakDetector.Level.DISABLED ); // Eats performance
          }
  
@@ -30,7 +30,7 @@ index 7ad603af..33390578 100644
  
          File moduleDirectory = new File( "modules" );
          moduleManager.load( this, moduleDirectory );
-@@ -378,7 +379,7 @@ public class BungeeCord extends ProxyServer
+@@ -352,7 +353,7 @@ public class BungeeCord extends ProxyServer
                      .option( ChannelOption.SO_REUSEADDR, true ) // TODO: Move this elsewhere!
                      .childAttr( PipelineUtils.LISTENER, info )
                      .childHandler( unsafe().getFrontendChannelInitializer().getChannelInitializer() )
@@ -39,7 +39,7 @@ index 7ad603af..33390578 100644
                      .localAddress( info.getSocketAddress() )
                      .bind().addListener( listener );
  
-@@ -401,7 +402,7 @@ public class BungeeCord extends ProxyServer
+@@ -375,7 +376,7 @@ public class BungeeCord extends ProxyServer
                          }
                      }
                  };
@@ -48,7 +48,7 @@ index 7ad603af..33390578 100644
              }
          }
      }
-@@ -510,12 +511,14 @@ public class BungeeCord extends ProxyServer
+@@ -484,12 +485,14 @@ public class BungeeCord extends ProxyServer
          }
  
          getLogger().info( "Closing IO threads" );
@@ -83,5 +83,5 @@ index 7700f1d6..0d24f1eb 100644
                  .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, BungeeCord.getInstance().getConfig().getRemotePingTimeout() )
                  .remoteAddress( socketAddress )
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0022-Add-dynamic-server-addition-removal-api.patch
+++ b/BungeeCord-Patches/0022-Add-dynamic-server-addition-removal-api.patch
@@ -1,4 +1,4 @@
-From cd4dc36e5aae4fdb8748598057b5d3a1370c6a30 Mon Sep 17 00:00:00 2001
+From c2147db2b709cbb986320dc40821ce076eb6391e Mon Sep 17 00:00:00 2001
 From: Troy Frew <fuzzy_bot@arenaga.me>
 Date: Wed, 29 Jun 2016 04:29:25 +0200
 Subject: [PATCH] Add dynamic server addition/removal api.
@@ -170,10 +170,10 @@ index 59c104d3..698b420f 100644
              private final String lower = ( args.length == 0 ) ? "" : args[0].toLowerCase( Locale.ROOT );
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 33390578..31707782 100644
+index 7fd69a3f..8f80a9be 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -683,10 +683,18 @@ public class BungeeCord extends ProxyServer
+@@ -657,10 +657,18 @@ public class BungeeCord extends ProxyServer
          return config.getServers();
      }
  
@@ -311,5 +311,5 @@ index 9e81fc6b..52b79ff5 100644
 +    // Waterfall end
  }
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0024-Improve-ServerKickEvent.patch
+++ b/BungeeCord-Patches/0024-Improve-ServerKickEvent.patch
@@ -1,4 +1,4 @@
-From f5bdbab090bb50cffa60ba8dbdee0aa5b45d9e0f Mon Sep 17 00:00:00 2001
+From a3e2e1537d0fdd51e62d084d64d67a2460ff813f Mon Sep 17 00:00:00 2001
 From: Nathan Poirier <nathan@poirier.io>
 Date: Tue, 28 Jun 2016 23:00:49 -0500
 Subject: [PATCH] Improve ServerKickEvent
@@ -68,10 +68,10 @@ index 3f9efaa8..5d2597ad 100644
      /**
       * @return the kick reason
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 38e06e4c..6d0ab7bd 100644
+index 26abaa80..44a73622 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -451,7 +451,7 @@ public class ServerConnector extends PacketHandler
+@@ -450,7 +450,7 @@ public class ServerConnector extends PacketHandler
          ServerKickEvent event = new ServerKickEvent( user, target, new BaseComponent[]
          {
              kick.getMessage()
@@ -81,10 +81,10 @@ index 38e06e4c..6d0ab7bd 100644
          {
              // Pre cancel the event if we are going to try another server
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 3c286239..7bac16e6 100644
+index ea693300..3e211afa 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -648,10 +648,14 @@ public class DownstreamBridge extends PacketHandler
+@@ -647,10 +647,14 @@ public class DownstreamBridge extends PacketHandler
      public void handle(Kick kick) throws Exception
      {
          ServerInfo def = con.updateAndGetNextServer( server.getInfo() );
@@ -101,5 +101,5 @@ index 3c286239..7bac16e6 100644
          {
              con.connectNow( event.getCancelServer(), ServerConnectEvent.Reason.KICK_REDIRECT );
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0024-Improve-ServerKickEvent.patch
+++ b/BungeeCord-Patches/0024-Improve-ServerKickEvent.patch
@@ -1,4 +1,4 @@
-From a3e2e1537d0fdd51e62d084d64d67a2460ff813f Mon Sep 17 00:00:00 2001
+From 5496972137855bac826642df02a03a771d8bbb2a Mon Sep 17 00:00:00 2001
 From: Nathan Poirier <nathan@poirier.io>
 Date: Tue, 28 Jun 2016 23:00:49 -0500
 Subject: [PATCH] Improve ServerKickEvent
@@ -81,10 +81,10 @@ index 26abaa80..44a73622 100644
          {
              // Pre cancel the event if we are going to try another server
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index ea693300..3e211afa 100644
+index 080ca279..33808905 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -647,10 +647,14 @@ public class DownstreamBridge extends PacketHandler
+@@ -648,10 +648,14 @@ public class DownstreamBridge extends PacketHandler
      public void handle(Kick kick) throws Exception
      {
          ServerInfo def = con.updateAndGetNextServer( server.getInfo() );

--- a/BungeeCord-Patches/0025-Configurable-server-version-in-ping-response.patch
+++ b/BungeeCord-Patches/0025-Configurable-server-version-in-ping-response.patch
@@ -1,4 +1,4 @@
-From 3d3293771dbced92be752768ac5e64627538b04d Mon Sep 17 00:00:00 2001
+From 9eccc2adcd6bbe0042f2bda2cb27b07b2071a421 Mon Sep 17 00:00:00 2001
 From: Troy Frew <fuzzy_bot@arenaga.me>
 Date: Wed, 29 Jun 2016 13:56:57 -0500
 Subject: [PATCH] Configurable server version in ping response
@@ -66,10 +66,10 @@ index 91743f01..111404fb 100644
      public int getTabThrottle() {
          return tabThrottle;
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 31707782..43dd0977 100644
+index 8f80a9be..9452af68 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -737,7 +737,7 @@ public class BungeeCord extends ProxyServer
+@@ -711,7 +711,7 @@ public class BungeeCord extends ProxyServer
      @Override
      public String getGameVersion()
      {
@@ -79,5 +79,5 @@ index 31707782..43dd0977 100644
  
      @Override
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0026-Add-timeout-variant-to-connect-methods.patch
+++ b/BungeeCord-Patches/0026-Add-timeout-variant-to-connect-methods.patch
@@ -1,4 +1,4 @@
-From 4e48fd0489a68acf7471ce0fc3a55add59ed9e87 Mon Sep 17 00:00:00 2001
+From 64fb78b6ba95fc44888e84bf937267f5574276cf Mon Sep 17 00:00:00 2001
 From: Ichbinjoe <joe@ibj.io>
 Date: Sat, 16 Jul 2016 20:44:01 -0400
 Subject: [PATCH] Add timeout variant to connect methods
@@ -75,10 +75,10 @@ index 0fe647b8..32af4937 100644
       * Connects / transfers this user to the specified connection, gracefully
       * closing the current one. Depending on the implementation, this method
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 1dc6be5d..92a7ef49 100644
+index 6287c3fc..2f22c9e0 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -309,9 +309,20 @@ public final class UserConnection implements ProxiedPlayer
+@@ -313,9 +313,20 @@ public final class UserConnection implements ProxiedPlayer
  
      public void connect(ServerInfo info, final Callback<Boolean> callback, final boolean retry, ServerConnectEvent.Reason reason)
      {
@@ -99,7 +99,7 @@ index 1dc6be5d..92a7ef49 100644
          if ( callback != null )
          {
              // Convert the Callback<Boolean> to be compatible with Callback<Result> from ServerConnectRequest.
-@@ -395,7 +406,7 @@ public final class UserConnection implements ProxiedPlayer
+@@ -399,7 +410,7 @@ public final class UserConnection implements ProxiedPlayer
                      if ( request.isRetry() && def != null && ( getServer() == null || def != getServer().getInfo() ) )
                      {
                          sendMessage( bungee.getTranslation( "fallback_lobby" ) );
@@ -109,5 +109,5 @@ index 1dc6be5d..92a7ef49 100644
                      {
                          disconnect( bungee.getTranslation( "fallback_kick", connectionFailMessage( future.cause() ) ) );
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0028-Dump-the-raw-hex-of-a-packet-on-a-decoding-error.patch
+++ b/BungeeCord-Patches/0028-Dump-the-raw-hex-of-a-packet-on-a-decoding-error.patch
@@ -1,11 +1,11 @@
-From 26e5efd5327231309bb9dcfc080e59baec9d6767 Mon Sep 17 00:00:00 2001
+From 7198a5ec6f032bf68e7974c6eeb59b97b487a2aa Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 4 Aug 2016 19:30:49 -0700
 Subject: [PATCH] Dump the raw hex of a packet on a decoding error
 
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index 250e7620..2207c3ff 100644
+index 1c21a330..2cfc5109 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 @@ -1,7 +1,9 @@
@@ -18,10 +18,10 @@ index 250e7620..2207c3ff 100644
  import io.netty.handler.codec.MessageToMessageDecoder;
  import java.util.List;
  import lombok.AllArgsConstructor;
-@@ -40,13 +42,16 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
-         Protocol.DirectionData prot = ( server ) ? protocol.TO_SERVER : protocol.TO_CLIENT;
-         ByteBuf slice = in.copy(); // Can't slice this one due to EntityMap :(
+@@ -38,13 +40,16 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
  
+         Protocol.DirectionData prot = ( server ) ? protocol.TO_SERVER : protocol.TO_CLIENT;
+         ByteBuf slice = ( copyBuffer ) ? in.copy() : in.retainedSlice();
 +        Object packetTypeInfo = null;
          try
          {
@@ -35,7 +35,7 @@ index 250e7620..2207c3ff 100644
                  packet.read( in, protocol, prot.getDirection(), protocolVersion );
  
                  if ( in.isReadable() )
-@@ -60,6 +65,16 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -58,6 +63,16 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
  
              out.add( new PacketWrapper( packet, slice, protocol ) );
              slice = null;
@@ -53,5 +53,5 @@ index 250e7620..2207c3ff 100644
          {
              if ( slice != null )
 -- 
-2.44.0
+2.43.0
 

--- a/BungeeCord-Patches/0029-Fix-potion-race-condition-on-Forge-1.8.9.patch
+++ b/BungeeCord-Patches/0029-Fix-potion-race-condition-on-Forge-1.8.9.patch
@@ -1,4 +1,4 @@
-From 6639aecbacc9db0f89e47475fa6e7c2d80790ace Mon Sep 17 00:00:00 2001
+From 90e84e3ce84b030d8e108e8145797d9696e50efb Mon Sep 17 00:00:00 2001
 From: Aaron Hill <aa1ronham@gmail.com>
 Date: Thu, 15 Sep 2016 22:38:37 +0200
 Subject: [PATCH] Fix potion race condition on Forge 1.8.9
@@ -117,7 +117,7 @@ index 00000000..7ed2dc3a
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index fd7d8799..7eda8f16 100644
+index 2f22c9e0..95b82a05 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 @@ -1,7 +1,9 @@
@@ -130,7 +130,7 @@ index fd7d8799..7eda8f16 100644
  import io.netty.bootstrap.Bootstrap;
  import io.netty.channel.ChannelFuture;
  import io.netty.channel.ChannelFutureListener;
-@@ -125,6 +127,10 @@ public final class UserConnection implements ProxiedPlayer
+@@ -126,6 +128,10 @@ public final class UserConnection implements ProxiedPlayer
      private final Scoreboard serverSentScoreboard = new Scoreboard();
      @Getter
      private final Collection<UUID> sentBossBars = new HashSet<>();
@@ -142,10 +142,10 @@ index fd7d8799..7eda8f16 100644
      @Setter
      private String lastCommandTabbed;
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 7bac16e6..9a12f002 100644
+index 3e211afa..c649d034 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -753,6 +753,32 @@ public class DownstreamBridge extends PacketHandler
+@@ -752,6 +752,32 @@ public class DownstreamBridge extends PacketHandler
          }
      }
  
@@ -217,5 +217,5 @@ index d15044f4..087cb4b0 100644
      /**
       * Sends the server mod list to the client, or stores it for sending later.
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0029-Fix-potion-race-condition-on-Forge-1.8.9.patch
+++ b/BungeeCord-Patches/0029-Fix-potion-race-condition-on-Forge-1.8.9.patch
@@ -1,4 +1,4 @@
-From 90e84e3ce84b030d8e108e8145797d9696e50efb Mon Sep 17 00:00:00 2001
+From 5d85339b1dd3b4d2a222c972f82cb3c3aad153a2 Mon Sep 17 00:00:00 2001
 From: Aaron Hill <aa1ronham@gmail.com>
 Date: Thu, 15 Sep 2016 22:38:37 +0200
 Subject: [PATCH] Fix potion race condition on Forge 1.8.9
@@ -117,7 +117,7 @@ index 00000000..7ed2dc3a
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 2f22c9e0..95b82a05 100644
+index eea0efc8..2e3269a2 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 @@ -1,7 +1,9 @@
@@ -142,10 +142,10 @@ index 2f22c9e0..95b82a05 100644
      @Setter
      private String lastCommandTabbed;
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 3e211afa..c649d034 100644
+index 33808905..4adb4b35 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -752,6 +752,32 @@ public class DownstreamBridge extends PacketHandler
+@@ -753,6 +753,32 @@ public class DownstreamBridge extends PacketHandler
          }
      }
  

--- a/BungeeCord-Patches/0033-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
+++ b/BungeeCord-Patches/0033-Use-Log4j2-for-logging-and-TerminalConsoleAppender-f.patch
@@ -1,4 +1,4 @@
-From 481079a9825975abc8723a13b3a416db2c446bcd Mon Sep 17 00:00:00 2001
+From da57da4aace3dd8229f343a9f4e244c3b7963fd2 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 22 Sep 2017 12:46:47 +0200
 Subject: [PATCH] Use Log4j2 for logging and TerminalConsoleAppender for
@@ -6,7 +6,7 @@ Subject: [PATCH] Use Log4j2 for logging and TerminalConsoleAppender for
 
 
 diff --git a/bootstrap/pom.xml b/bootstrap/pom.xml
-index 40c5073d..15c0adf2 100644
+index 9a8cec20..71bda913 100644
 --- a/bootstrap/pom.xml
 +++ b/bootstrap/pom.xml
 @@ -49,6 +49,9 @@
@@ -39,7 +39,7 @@ index 40c5073d..15c0adf2 100644
      </build>
 diff --git a/log4j/pom.xml b/log4j/pom.xml
 new file mode 100644
-index 00000000..c145f8f2
+index 00000000..5a21bdad
 --- /dev/null
 +++ b/log4j/pom.xml
 @@ -0,0 +1,48 @@
@@ -50,13 +50,13 @@ index 00000000..c145f8f2
 +    <parent>
 +        <groupId>io.github.waterfallmc</groupId>
 +        <artifactId>waterfall-parent</artifactId>
-+        <version>1.21-R0.2-SNAPSHOT</version>
++        <version>1.21-R0.3-SNAPSHOT</version>
 +        <relativePath>../pom.xml</relativePath>
 +    </parent>
 +
 +    <groupId>io.github.waterfallmc</groupId>
 +    <artifactId>waterfall-log4j</artifactId>
-+    <version>1.21-R0.2-SNAPSHOT</version>
++    <version>1.21-R0.3-SNAPSHOT</version>
 +    <packaging>jar</packaging>
 +
 +    <name>Waterfall-Log4J</name>
@@ -233,7 +233,7 @@ index 00000000..cfd039cd
 +    </Loggers>
 +</Configuration>
 diff --git a/pom.xml b/pom.xml
-index 454eb788..f1105771 100644
+index e1da472e..dfcebb8c 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -48,12 +48,13 @@
@@ -253,7 +253,7 @@ index 454eb788..f1105771 100644
      </modules>
  
 diff --git a/proxy/pom.xml b/proxy/pom.xml
-index 84dbc9de..4e69cc18 100644
+index d5896858..fac2e818 100644
 --- a/proxy/pom.xml
 +++ b/proxy/pom.xml
 @@ -83,7 +83,7 @@
@@ -362,10 +362,10 @@ index 00000000..765d24bc
 +
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 43dd0977..30564c2a 100644
+index 9452af68..5e43f8d7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -48,7 +48,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
+@@ -46,7 +46,6 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  import java.util.logging.Handler;
  import java.util.logging.Level;
  import java.util.logging.Logger;
@@ -373,7 +373,7 @@ index 43dd0977..30564c2a 100644
  import lombok.Getter;
  import lombok.Setter;
  import lombok.Synchronized;
-@@ -83,15 +82,11 @@ import net.md_5.bungee.command.CommandEnd;
+@@ -67,15 +66,11 @@ import net.md_5.bungee.command.CommandEnd;
  import net.md_5.bungee.command.CommandIP;
  import net.md_5.bungee.command.CommandPerms;
  import net.md_5.bungee.command.CommandReload;
@@ -389,7 +389,7 @@ index 43dd0977..30564c2a 100644
  import net.md_5.bungee.module.ModuleManager;
  import net.md_5.bungee.netty.PipelineUtils;
  import net.md_5.bungee.protocol.DefinedPacket;
-@@ -101,8 +96,6 @@ import net.md_5.bungee.protocol.packet.PluginMessage;
+@@ -85,8 +80,6 @@ import net.md_5.bungee.protocol.packet.PluginMessage;
  import net.md_5.bungee.query.RemoteQuery;
  import net.md_5.bungee.scheduler.BungeeScheduler;
  import net.md_5.bungee.util.CaseInsensitiveMap;
@@ -398,7 +398,7 @@ index 43dd0977..30564c2a 100644
  
  /**
   * Main BungeeCord proxy class.
-@@ -162,8 +155,12 @@ public class BungeeCord extends ProxyServer
+@@ -146,8 +139,12 @@ public class BungeeCord extends ProxyServer
      private final File pluginsFolder = new File( "plugins" );
      @Getter
      private final BungeeScheduler scheduler = new BungeeScheduler();
@@ -410,8 +410,8 @@ index 43dd0977..30564c2a 100644
 +    // Waterfall end
      @Getter
      private final Logger logger;
-     public final Gson gson = new GsonBuilder()
-@@ -223,6 +220,8 @@ public class BungeeCord extends ProxyServer
+     @Getter
+@@ -197,6 +194,8 @@ public class BungeeCord extends ProxyServer
          // BungeeCord. This version is only used when extracting the libraries to their temp folder.
          System.setProperty( "library.jansi.version", "BungeeCord" );
  
@@ -420,7 +420,7 @@ index 43dd0977..30564c2a 100644
          AnsiConsole.systemInstall();
          consoleReader = new ConsoleReader();
          consoleReader.setExpandEvents( false );
-@@ -247,6 +246,9 @@ public class BungeeCord extends ProxyServer
+@@ -221,6 +220,9 @@ public class BungeeCord extends ProxyServer
          // since it applies a nice looking format and also writes to the logfile.
          System.setErr( new PrintStream( new LoggingOutputStream( logger, Level.SEVERE ), true ) );
          System.setOut( new PrintStream( new LoggingOutputStream( logger, Level.INFO ), true ) );
@@ -430,7 +430,7 @@ index 43dd0977..30564c2a 100644
  
          pluginManager = new PluginManager( this );
          getPluginManager().registerCommand( null, new CommandReload() );
-@@ -523,10 +525,7 @@ public class BungeeCord extends ProxyServer
+@@ -497,10 +499,7 @@ public class BungeeCord extends ProxyServer
  
          getLogger().info( "Thank you and goodbye" );
          // Need to close loggers after last message!
@@ -1575,5 +1575,5 @@ index 21a48df6..00000000
 -
 -}
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0038-Providing-access-to-the-player-s-LoginResult-on-Logi.patch
+++ b/BungeeCord-Patches/0038-Providing-access-to-the-player-s-LoginResult-on-Logi.patch
@@ -1,4 +1,4 @@
-From 7ce1a6b01a3f10e6d2a288b1dfd6c894d7a076fa Mon Sep 17 00:00:00 2001
+From 06a2a952654fa201c0d9faebedc250ee25ba919b Mon Sep 17 00:00:00 2001
 From: phenomax <phenomax@revayd.net>
 Date: Thu, 10 Aug 2017 18:41:17 +0200
 Subject: [PATCH] Providing access to the player's LoginResult on LoginEvent
@@ -51,10 +51,10 @@ similarity index 100%
 rename from proxy/src/main/java/net/md_5/bungee/connection/LoginResult.java
 rename to api/src/main/java/net/md_5/bungee/connection/LoginResult.java
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index c86121d5..2ad70524 100644
+index 041c3103..1e615fa7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -48,6 +48,7 @@ import net.md_5.bungee.api.event.PostLoginEvent;
+@@ -47,6 +47,7 @@ import net.md_5.bungee.api.event.PostLoginEvent;
  import net.md_5.bungee.api.event.PreLoginEvent;
  import net.md_5.bungee.api.event.ProxyPingEvent;
  import net.md_5.bungee.api.event.ServerConnectEvent;
@@ -62,7 +62,7 @@ index c86121d5..2ad70524 100644
  import net.md_5.bungee.http.HttpClient;
  import net.md_5.bungee.jni.cipher.BungeeCipher;
  import net.md_5.bungee.netty.ChannelWrapper;
-@@ -631,7 +632,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -630,7 +631,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          };
  
          // fire login event
@@ -72,5 +72,5 @@ index c86121d5..2ad70524 100644
  
      private void finish2()
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0038-Providing-access-to-the-player-s-LoginResult-on-Logi.patch
+++ b/BungeeCord-Patches/0038-Providing-access-to-the-player-s-LoginResult-on-Logi.patch
@@ -1,4 +1,4 @@
-From 06a2a952654fa201c0d9faebedc250ee25ba919b Mon Sep 17 00:00:00 2001
+From 20a843d59cc915d9f59310a99598c9b6467797e9 Mon Sep 17 00:00:00 2001
 From: phenomax <phenomax@revayd.net>
 Date: Thu, 10 Aug 2017 18:41:17 +0200
 Subject: [PATCH] Providing access to the player's LoginResult on LoginEvent
@@ -51,10 +51,10 @@ similarity index 100%
 rename from proxy/src/main/java/net/md_5/bungee/connection/LoginResult.java
 rename to api/src/main/java/net/md_5/bungee/connection/LoginResult.java
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 041c3103..1e615fa7 100644
+index 217030d2..40d2e6c8 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -47,6 +47,7 @@ import net.md_5.bungee.api.event.PostLoginEvent;
+@@ -48,6 +48,7 @@ import net.md_5.bungee.api.event.PostLoginEvent;
  import net.md_5.bungee.api.event.PreLoginEvent;
  import net.md_5.bungee.api.event.ProxyPingEvent;
  import net.md_5.bungee.api.event.ServerConnectEvent;
@@ -62,7 +62,7 @@ index 041c3103..1e615fa7 100644
  import net.md_5.bungee.http.HttpClient;
  import net.md_5.bungee.jni.cipher.BungeeCipher;
  import net.md_5.bungee.netty.ChannelWrapper;
-@@ -630,7 +631,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -633,7 +634,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          };
  
          // fire login event

--- a/BungeeCord-Patches/0039-Optionally-log-InitialHandler-connections.patch
+++ b/BungeeCord-Patches/0039-Optionally-log-InitialHandler-connections.patch
@@ -1,4 +1,4 @@
-From 8bc971b4bbb71ab8b06a2309987e14cf2acf6f7d Mon Sep 17 00:00:00 2001
+From 965e07334d04233fc7f96c915628f649f320aefc Mon Sep 17 00:00:00 2001
 From: Gabriele C <sgdc3.mail@gmail.com>
 Date: Thu, 8 Feb 2018 19:10:52 +0100
 Subject: [PATCH] Optionally log InitialHandler connections
@@ -61,10 +61,10 @@ index ef44d334..4ff8da6d 100644
      public String getGameVersion() {
          return gameVersion;
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 2ad70524..3fe70fd8 100644
+index 1e615fa7..14bcf182 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -393,7 +393,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -392,7 +392,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
              case 3:
                  transferred = handshake.getRequestedProtocol() == 3;
                  // Login
@@ -77,5 +77,5 @@ index 2ad70524..3fe70fd8 100644
                  ch.setProtocol( Protocol.LOGIN );
  
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0039-Optionally-log-InitialHandler-connections.patch
+++ b/BungeeCord-Patches/0039-Optionally-log-InitialHandler-connections.patch
@@ -1,4 +1,4 @@
-From 965e07334d04233fc7f96c915628f649f320aefc Mon Sep 17 00:00:00 2001
+From 3de49f66f500acafa26446ee394f1c9ff44b834b Mon Sep 17 00:00:00 2001
 From: Gabriele C <sgdc3.mail@gmail.com>
 Date: Thu, 8 Feb 2018 19:10:52 +0100
 Subject: [PATCH] Optionally log InitialHandler connections
@@ -61,10 +61,10 @@ index ef44d334..4ff8da6d 100644
      public String getGameVersion() {
          return gameVersion;
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 1e615fa7..14bcf182 100644
+index 40d2e6c8..31cdbe48 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -392,7 +392,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -395,7 +395,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
              case 3:
                  transferred = handshake.getRequestedProtocol() == 3;
                  // Login

--- a/BungeeCord-Patches/0040-Forge-is-a-first-class-citizen.patch
+++ b/BungeeCord-Patches/0040-Forge-is-a-first-class-citizen.patch
@@ -1,14 +1,14 @@
-From 0af7f17e15751b88ef2d2aa512e98c2b9989ba34 Mon Sep 17 00:00:00 2001
+From 5ca0009820e5aa93201bd9df7b4f15b57067ffc6 Mon Sep 17 00:00:00 2001
 From: Jamie Mansfield <dev@jamierocks.uk>
 Date: Mon, 28 May 2018 21:43:55 +0100
 Subject: [PATCH] Forge is a first class citizen
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 30564c2a..e7f5e598 100644
+index 5e43f8d7..db0b5a10 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -309,8 +309,6 @@ public class BungeeCord extends ProxyServer
+@@ -283,8 +283,6 @@ public class BungeeCord extends ProxyServer
              registerChannel( ForgeConstants.FML_TAG );
              registerChannel( ForgeConstants.FML_HANDSHAKE_TAG );
              registerChannel( ForgeConstants.FORGE_REGISTER );
@@ -34,5 +34,5 @@ index 52b79ff5..8a03a0ce 100644
      @Synchronized("serversLock") // Waterfall
      public void load()
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0041-Ignore-empty-packets.patch
+++ b/BungeeCord-Patches/0041-Ignore-empty-packets.patch
@@ -1,4 +1,4 @@
-From 49038909ac940a1e6ccda7dd8d71fedf71f3bdb9 Mon Sep 17 00:00:00 2001
+From 9e16ba9829322871d7b1221588161aa6db01eb10 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Fri, 12 Oct 2018 14:28:52 +0100
 Subject: [PATCH] Ignore empty packets
@@ -8,10 +8,10 @@ packets will be ignored. While empty packets are a sign of bad plugins,
 they are effectivly harmless vs the cost of the exception in general
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index 2207c3ff..655bcd46 100644
+index 2cfc5109..8941a575 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-@@ -45,6 +45,12 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -43,6 +43,12 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
          Object packetTypeInfo = null;
          try
          {
@@ -38,5 +38,5 @@ index 277e70e8..cf7dea17 100644
                      throw new CorruptedFrameException( "Empty Packet!" );
                  }
 -- 
-2.44.0
+2.43.0
 

--- a/BungeeCord-Patches/0043-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0043-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From a05c46decea7a601c5c42e4809a5ce4d94072a43 Mon Sep 17 00:00:00 2001
+From 008fa635f6dfb6fae278ff403f0770ec8fae6ae0 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -123,10 +123,10 @@ index 44a73622..8ae8a30b 100644
                      (byte) 0, login.getDeathLocation(), login.getPortalCooldown(), login.getSeaLevel() ) );
              if ( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_14 )
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 95b82a05..fda671ec 100644
+index 2e3269a2..f6da8235 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -841,4 +841,9 @@ public final class UserConnection implements ProxiedPlayer
+@@ -846,4 +846,9 @@ public final class UserConnection implements ProxiedPlayer
  
          unsafe().sendPacket( new Transfer( host, port ) );
      }
@@ -137,10 +137,10 @@ index 95b82a05..fda671ec 100644
 +    // Waterfall end
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index c649d034..d17a585d 100644
+index 4adb4b35..4fceb653 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -756,6 +756,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -757,6 +757,7 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(net.md_5.bungee.protocol.packet.EntityEffect entityEffect) throws Exception
      {
@@ -148,7 +148,7 @@ index c649d034..d17a585d 100644
          // Don't send any potions when switching between servers (which involves a handshake), which can trigger a race
          // condition on the client.
          if (this.con.getForgeClientHandler().isForgeUser() && !this.con.getForgeClientHandler().isHandshakeComplete()) {
-@@ -767,6 +768,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -768,6 +769,7 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(net.md_5.bungee.protocol.packet.EntityRemoveEffect removeEffect) throws Exception
      {
@@ -157,7 +157,7 @@ index c649d034..d17a585d 100644
      }
  
 diff --git a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
-index 1bf73fd2..243acba6 100644
+index 1a27d786..140430c9 100644
 --- a/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 +++ b/proxy/src/main/java/net/md_5/bungee/entitymap/EntityMap.java
 @@ -27,6 +27,11 @@ public abstract class EntityMap
@@ -172,7 +172,7 @@ index 1bf73fd2..243acba6 100644
          switch ( version )
          {
              case ProtocolConstants.MINECRAFT_1_8:
-@@ -311,7 +316,13 @@ public abstract class EntityMap
+@@ -299,7 +304,13 @@ public abstract class EntityMap
                      DefinedPacket.readVarInt( packet );
                      break;
                  default:

--- a/BungeeCord-Patches/0043-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0043-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From 1474f598740d2d15dcb97b96f9a395e5fed00a24 Mon Sep 17 00:00:00 2001
+From a05c46decea7a601c5c42e4809a5ce4d94072a43 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -57,10 +57,10 @@ index 4ff8da6d..e860214f 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 6d0ab7bd..0b82fee9 100644
+index 44a73622..8ae8a30b 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-@@ -274,7 +274,8 @@ public class ServerConnector extends PacketHandler
+@@ -273,7 +273,8 @@ public class ServerConnector extends PacketHandler
              ch.write( new PluginMessage( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_13 ? "minecraft:register" : "REGISTER", Joiner.on( "\0" ).join( registeredChannels ).getBytes( StandardCharsets.UTF_8 ), false ) );
          }
  
@@ -70,7 +70,7 @@ index 6d0ab7bd..0b82fee9 100644
          {
              ch.write( user.getSettings() );
          }
-@@ -329,6 +330,7 @@ public class ServerConnector extends PacketHandler
+@@ -328,6 +329,7 @@ public class ServerConnector extends PacketHandler
              user.getTabListHandler().onServerChange();
  
              Scoreboard serverScoreboard = user.getServerSentScoreboard();
@@ -78,7 +78,7 @@ index 6d0ab7bd..0b82fee9 100644
              for ( Objective objective : serverScoreboard.getObjectives() )
              {
                  user.unsafe().sendPacket( new ScoreboardObjective(
-@@ -352,6 +354,7 @@ public class ServerConnector extends PacketHandler
+@@ -351,6 +353,7 @@ public class ServerConnector extends PacketHandler
              {
                  user.unsafe().sendPacket( new net.md_5.bungee.protocol.packet.Team( team.getName() ) );
              }
@@ -86,7 +86,7 @@ index 6d0ab7bd..0b82fee9 100644
              serverScoreboard.clear();
  
              for ( UUID bossbar : user.getSentBossBars() )
-@@ -370,13 +373,34 @@ public class ServerConnector extends PacketHandler
+@@ -369,13 +372,34 @@ public class ServerConnector extends PacketHandler
              }
  
              user.setDimensionChange( true );
@@ -123,10 +123,10 @@ index 6d0ab7bd..0b82fee9 100644
                      (byte) 0, login.getDeathLocation(), login.getPortalCooldown(), login.getSeaLevel() ) );
              if ( user.getPendingConnection().getVersion() >= ProtocolConstants.MINECRAFT_1_14 )
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index f68041db..372b95e1 100644
+index 95b82a05..fda671ec 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -837,4 +837,9 @@ public final class UserConnection implements ProxiedPlayer
+@@ -841,4 +841,9 @@ public final class UserConnection implements ProxiedPlayer
  
          unsafe().sendPacket( new Transfer( host, port ) );
      }
@@ -137,10 +137,10 @@ index f68041db..372b95e1 100644
 +    // Waterfall end
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 9a12f002..7a24bacd 100644
+index c649d034..d17a585d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -757,6 +757,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -756,6 +756,7 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(net.md_5.bungee.protocol.packet.EntityEffect entityEffect) throws Exception
      {
@@ -148,7 +148,7 @@ index 9a12f002..7a24bacd 100644
          // Don't send any potions when switching between servers (which involves a handshake), which can trigger a race
          // condition on the client.
          if (this.con.getForgeClientHandler().isForgeUser() && !this.con.getForgeClientHandler().isHandshakeComplete()) {
-@@ -768,6 +769,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -767,6 +768,7 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(net.md_5.bungee.protocol.packet.EntityRemoveEffect removeEffect) throws Exception
      {
@@ -225,5 +225,5 @@ index 00000000..cb81d1dd
 +// Waterfall end
 \ No newline at end of file
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0044-Add-ProxyDefineCommandsEvent.patch
+++ b/BungeeCord-Patches/0044-Add-ProxyDefineCommandsEvent.patch
@@ -1,4 +1,4 @@
-From 046bc4f98220c0620a3ee2e2731cb39b9934edb9 Mon Sep 17 00:00:00 2001
+From 9978e8c15ffcdbc531e392eba7dc77529bb6e47f Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Thu, 14 Mar 2019 07:44:06 +0000
 Subject: [PATCH] Add ProxyDefineCommandsEvent
@@ -54,10 +54,10 @@ index 00000000..1fd4fc90
 +
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 7a24bacd..8152e638 100644
+index d17a585d..5eab4a1e 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -792,9 +792,25 @@ public class DownstreamBridge extends PacketHandler
+@@ -791,9 +791,25 @@ public class DownstreamBridge extends PacketHandler
      {
          boolean modified = false;
  
@@ -86,5 +86,5 @@ index 7a24bacd..8152e638 100644
                  CommandNode dummy = LiteralArgumentBuilder.literal( command.getKey() ).executes( DUMMY_COMMAND )
                          .then( RequiredArgumentBuilder.argument( "args", StringArgumentType.greedyString() )
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0044-Add-ProxyDefineCommandsEvent.patch
+++ b/BungeeCord-Patches/0044-Add-ProxyDefineCommandsEvent.patch
@@ -1,4 +1,4 @@
-From 9978e8c15ffcdbc531e392eba7dc77529bb6e47f Mon Sep 17 00:00:00 2001
+From 5de61818229ed245a791df41575113aec11509b0 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Thu, 14 Mar 2019 07:44:06 +0000
 Subject: [PATCH] Add ProxyDefineCommandsEvent
@@ -54,10 +54,10 @@ index 00000000..1fd4fc90
 +
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index d17a585d..5eab4a1e 100644
+index 4fceb653..4a269256 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -791,9 +791,25 @@ public class DownstreamBridge extends PacketHandler
+@@ -792,9 +792,25 @@ public class DownstreamBridge extends PacketHandler
      {
          boolean modified = false;
  

--- a/BungeeCord-Patches/0047-Speed-up-some-common-exceptions.patch
+++ b/BungeeCord-Patches/0047-Speed-up-some-common-exceptions.patch
@@ -1,4 +1,4 @@
-From 14637f321215334588abbeba6b9788d3429fed60 Mon Sep 17 00:00:00 2001
+From 808743c66a48638dbecfac56ed92fa4356466f7c Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 25 Nov 2019 19:54:06 +0000
 Subject: [PATCH] Speed up some common exceptions
@@ -125,10 +125,10 @@ index 00000000..2583aa2c
 +    }
 +}
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index 655bcd46..52f76cd9 100644
+index 8941a575..7992143f 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-@@ -80,7 +80,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -78,7 +78,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
              } else {
                  packetTypeStr = "unknown";
              }
@@ -172,10 +172,10 @@ index 237955ab..d0bd4d75 100644
 +    // Waterfall end
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 14bcf182..d7528262 100644
+index 31cdbe48..b8f1010e 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -23,6 +23,8 @@ import javax.crypto.SecretKey;
+@@ -24,6 +24,8 @@ import javax.crypto.SecretKey;
  import lombok.AllArgsConstructor;
  import lombok.Data;
  import lombok.EqualsAndHashCode;
@@ -184,7 +184,7 @@ index 14bcf182..d7528262 100644
  import lombok.Getter;
  import lombok.RequiredArgsConstructor;
  import lombok.ToString;
-@@ -510,6 +512,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -513,6 +515,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          Preconditions.checkState( EncryptionUtil.check( loginRequest.getPublicKey(), encryptResponse, request ), "Invalid verification" );
  
          SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );

--- a/BungeeCord-Patches/0047-Speed-up-some-common-exceptions.patch
+++ b/BungeeCord-Patches/0047-Speed-up-some-common-exceptions.patch
@@ -1,4 +1,4 @@
-From fc02f71116d3d9cf2ff5e8a0b1f788aaf9cdbe6f Mon Sep 17 00:00:00 2001
+From 14637f321215334588abbeba6b9788d3429fed60 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 25 Nov 2019 19:54:06 +0000
 Subject: [PATCH] Speed up some common exceptions
@@ -59,10 +59,10 @@ index 6c0ef4df..076ddd70 100644
 +    // Waterfall end
  }
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
-index c0940352..02d39adf 100644
+index b2a4729c..17490208 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
-@@ -48,6 +48,9 @@ public abstract class DefinedPacket
+@@ -47,6 +47,9 @@ public abstract class DefinedPacket
          }
      }
  
@@ -72,7 +72,7 @@ index c0940352..02d39adf 100644
      public static void writeString(String s, ByteBuf buf)
      {
          writeString( s, buf, Short.MAX_VALUE );
-@@ -252,13 +255,18 @@ public abstract class DefinedPacket
+@@ -251,13 +254,18 @@ public abstract class DefinedPacket
          byte in;
          while ( true )
          {
@@ -172,10 +172,10 @@ index 237955ab..d0bd4d75 100644
 +    // Waterfall end
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 3fe70fd8..c52f9332 100644
+index 14bcf182..d7528262 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -24,6 +24,8 @@ import javax.crypto.SecretKey;
+@@ -23,6 +23,8 @@ import javax.crypto.SecretKey;
  import lombok.AllArgsConstructor;
  import lombok.Data;
  import lombok.EqualsAndHashCode;
@@ -184,7 +184,7 @@ index 3fe70fd8..c52f9332 100644
  import lombok.Getter;
  import lombok.RequiredArgsConstructor;
  import lombok.ToString;
-@@ -511,6 +513,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -510,6 +512,14 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          Preconditions.checkState( EncryptionUtil.check( loginRequest.getPublicKey(), encryptResponse, request ), "Invalid verification" );
  
          SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );
@@ -221,5 +221,5 @@ index ac99d02c..0c1ecfb8 100644
  
              // Waterfall start
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0048-ConnectionInitEvent.patch
+++ b/BungeeCord-Patches/0048-ConnectionInitEvent.patch
@@ -1,4 +1,4 @@
-From 07b913d9d62815a76774307a887956ac5053f18e Mon Sep 17 00:00:00 2001
+From b30225efe770665938c1d382152c71385c217b6d Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 2 Dec 2019 11:35:17 +0000
 Subject: [PATCH] ConnectionInitEvent
@@ -67,7 +67,7 @@ index 00000000..6e79675f
 +    }
 +}
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index 77a458cc..b8b4b23c 100644
+index a6d1b287..bd40e88c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 @@ -1,6 +1,7 @@
@@ -78,7 +78,7 @@ index 77a458cc..b8b4b23c 100644
  import io.netty.buffer.PooledByteBufAllocator;
  import io.netty.channel.Channel;
  import io.netty.channel.ChannelException;
-@@ -75,8 +76,23 @@ public class PipelineUtils
+@@ -76,8 +77,23 @@ public class PipelineUtils
              {
                  return false;
              }
@@ -103,7 +103,7 @@ index 77a458cc..b8b4b23c 100644
              ch.pipeline().addBefore( FRAME_DECODER, LEGACY_DECODER, new LegacyDecoder() );
              ch.pipeline().addAfter( FRAME_DECODER, PACKET_DECODER, new MinecraftDecoder( Protocol.HANDSHAKE, true, ProxyServer.getInstance().getProtocolVersion() ) );
              ch.pipeline().addAfter( FRAME_PREPENDER_AND_COMPRESS, PACKET_ENCODER, new MinecraftEncoder( Protocol.HANDSHAKE, true, ProxyServer.getInstance().getProtocolVersion() ) );
-@@ -95,6 +111,10 @@ public class PipelineUtils
+@@ -96,6 +112,10 @@ public class PipelineUtils
              {
                  ch.pipeline().addFirst( new HAProxyMessageDecoder() );
              }
@@ -115,5 +115,5 @@ index 77a458cc..b8b4b23c 100644
              return true;
          } ) );
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0049-Add-exception-reporting-event.patch
+++ b/BungeeCord-Patches/0049-Add-exception-reporting-event.patch
@@ -1,4 +1,4 @@
-From 82a0b2c3688e8dfb773bb1d3948154722fe015a6 Mon Sep 17 00:00:00 2001
+From 0403b7aae16e5d21bf9b6d82b4e308b4271a15c4 Mon Sep 17 00:00:00 2001
 From: theminecoder <theminecoder.dev@gmail.com>
 Date: Wed, 22 Apr 2020 14:00:44 +1000
 Subject: [PATCH] Add exception reporting event
@@ -642,11 +642,11 @@ index 014de202..40792a68 100644
  
      @EventHandler
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index e7f5e598..27988fd5 100644
+index db0b5a10..bdd8565c 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -10,6 +10,8 @@ import com.google.gson.Gson;
- import com.google.gson.GsonBuilder;
+@@ -8,6 +8,8 @@ import com.google.common.collect.Sets;
+ import com.google.common.util.concurrent.ThreadFactoryBuilder;
  import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  import io.github.waterfallmc.waterfall.conf.WaterfallConfiguration;
 +import io.github.waterfallmc.waterfall.event.ProxyExceptionEvent;
@@ -654,7 +654,7 @@ index e7f5e598..27988fd5 100644
  import io.netty.bootstrap.ServerBootstrap;
  import io.netty.channel.Channel;
  import io.netty.channel.ChannelException;
-@@ -504,7 +506,11 @@ public class BungeeCord extends ProxyServer
+@@ -478,7 +480,11 @@ public class BungeeCord extends ProxyServer
                  }
              } catch ( Throwable t )
              {
@@ -695,5 +695,5 @@ index 38b75b51..02ec98fc 100644
  
              // If we have a period of 0 or less, only run once
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0050-Allow-to-disable-tablist-rewrite.patch
+++ b/BungeeCord-Patches/0050-Allow-to-disable-tablist-rewrite.patch
@@ -1,4 +1,4 @@
-From 6221c90b2631cdc8ba0b0047002e41a92e824898 Mon Sep 17 00:00:00 2001
+From de1fbe8b2c4006838c6f7d189426dfe9400a82b6 Mon Sep 17 00:00:00 2001
 From: xDark <aleshkailyashevich@gmail.com>
 Date: Fri, 31 May 2019 08:11:31 +0300
 Subject: [PATCH] Allow to disable tablist rewrite
@@ -50,10 +50,10 @@ index e860214f..b88e3c8a 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 5eab4a1e..bca0a9c7 100644
+index 4a269256..adf8621f 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -170,8 +170,14 @@ public class DownstreamBridge extends PacketHandler
+@@ -171,8 +171,14 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(PlayerListItem playerList) throws Exception
      {

--- a/BungeeCord-Patches/0050-Allow-to-disable-tablist-rewrite.patch
+++ b/BungeeCord-Patches/0050-Allow-to-disable-tablist-rewrite.patch
@@ -1,4 +1,4 @@
-From 10d6d10e393b7642c67a334d1da7279c8f8e9275 Mon Sep 17 00:00:00 2001
+From 6221c90b2631cdc8ba0b0047002e41a92e824898 Mon Sep 17 00:00:00 2001
 From: xDark <aleshkailyashevich@gmail.com>
 Date: Fri, 31 May 2019 08:11:31 +0300
 Subject: [PATCH] Allow to disable tablist rewrite
@@ -50,10 +50,10 @@ index e860214f..b88e3c8a 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 7b9c9268..96655cb7 100644
+index 5eab4a1e..bca0a9c7 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -171,8 +171,14 @@ public class DownstreamBridge extends PacketHandler
+@@ -170,8 +170,14 @@ public class DownstreamBridge extends PacketHandler
      @Override
      public void handle(PlayerListItem playerList) throws Exception
      {
@@ -71,5 +71,5 @@ index 7b9c9268..96655cb7 100644
  
      @Override
 -- 
-2.47.0
+2.43.0
 

--- a/BungeeCord-Patches/0051-Remove-version-from-brand-info.patch
+++ b/BungeeCord-Patches/0051-Remove-version-from-brand-info.patch
@@ -1,14 +1,14 @@
-From 0921398e8478905357fc37c27194c9a7bf6308dc Mon Sep 17 00:00:00 2001
+From b3a1df1ff213d152db93fdaeb861b3d501494a39 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sat, 20 Jun 2020 18:21:17 +0100
 Subject: [PATCH] Remove version from brand info
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index bca0a9c7..c638637d 100644
+index adf8621f..a0242037 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -331,7 +331,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -332,7 +332,7 @@ public class DownstreamBridge extends PacketHandler
              Preconditions.checkState( !serverBrand.contains( bungee.getName() ), "Cannot connect proxy to itself!" );
  
              brand = ByteBufAllocator.DEFAULT.heapBuffer();

--- a/BungeeCord-Patches/0051-Remove-version-from-brand-info.patch
+++ b/BungeeCord-Patches/0051-Remove-version-from-brand-info.patch
@@ -1,14 +1,14 @@
-From 6803974ba636d9e76dd77a8b35e2ada91344f288 Mon Sep 17 00:00:00 2001
+From 0921398e8478905357fc37c27194c9a7bf6308dc Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sat, 20 Jun 2020 18:21:17 +0100
 Subject: [PATCH] Remove version from brand info
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-index 1596b1eb..399b4e7d 100644
+index bca0a9c7..c638637d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/DownstreamBridge.java
-@@ -332,7 +332,7 @@ public class DownstreamBridge extends PacketHandler
+@@ -331,7 +331,7 @@ public class DownstreamBridge extends PacketHandler
              Preconditions.checkState( !serverBrand.contains( bungee.getName() ), "Cannot connect proxy to itself!" );
  
              brand = ByteBufAllocator.DEFAULT.heapBuffer();
@@ -18,5 +18,5 @@ index 1596b1eb..399b4e7d 100644
              brand.release();
              // changes in the packet are ignored so we need to send it manually
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0052-Add-auth-url-option.patch
+++ b/BungeeCord-Patches/0052-Add-auth-url-option.patch
@@ -1,14 +1,14 @@
-From 39c7fb4fc07205ef2c19913dd56dda375a3d863f Mon Sep 17 00:00:00 2001
+From b6adb769676028eaed85d6568ea1e3d621e870de Mon Sep 17 00:00:00 2001
 From: theminecoder <theminecoder.dev@gmail.com>
 Date: Sun, 19 Jul 2020 10:18:23 +1000
 Subject: [PATCH] Add auth url option
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index d7528262..9149e329 100644
+index b8f1010e..16cc5ff4 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -88,6 +88,8 @@ import net.md_5.bungee.util.QuietException;
+@@ -89,6 +89,8 @@ import net.md_5.bungee.util.QuietException;
  public class InitialHandler extends PacketHandler implements PendingConnection
  {
  
@@ -17,7 +17,7 @@ index d7528262..9149e329 100644
      private final BungeeCord bungee;
      private ChannelWrapper ch;
      @Getter
-@@ -540,7 +542,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -543,7 +545,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          String encodedHash = URLEncoder.encode( new BigInteger( sha.digest() ).toString( 16 ), "UTF-8" );
  
          String preventProxy = ( BungeeCord.getInstance().config.isPreventProxyConnections() && getSocketAddress() instanceof InetSocketAddress ) ? "&ip=" + URLEncoder.encode( getAddress().getAddress().getHostAddress(), "UTF-8" ) : "";

--- a/BungeeCord-Patches/0052-Add-auth-url-option.patch
+++ b/BungeeCord-Patches/0052-Add-auth-url-option.patch
@@ -1,14 +1,14 @@
-From b639339582d15fb7842ff0eca13f5067d44bea38 Mon Sep 17 00:00:00 2001
+From 39c7fb4fc07205ef2c19913dd56dda375a3d863f Mon Sep 17 00:00:00 2001
 From: theminecoder <theminecoder.dev@gmail.com>
 Date: Sun, 19 Jul 2020 10:18:23 +1000
 Subject: [PATCH] Add auth url option
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index c52f9332..5b81eced 100644
+index d7528262..9149e329 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -89,6 +89,8 @@ import net.md_5.bungee.util.QuietException;
+@@ -88,6 +88,8 @@ import net.md_5.bungee.util.QuietException;
  public class InitialHandler extends PacketHandler implements PendingConnection
  {
  
@@ -17,7 +17,7 @@ index c52f9332..5b81eced 100644
      private final BungeeCord bungee;
      private ChannelWrapper ch;
      @Getter
-@@ -541,7 +543,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -540,7 +542,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          String encodedHash = URLEncoder.encode( new BigInteger( sha.digest() ).toString( 16 ), "UTF-8" );
  
          String preventProxy = ( BungeeCord.getInstance().config.isPreventProxyConnections() && getSocketAddress() instanceof InetSocketAddress ) ? "&ip=" + URLEncoder.encode( getAddress().getAddress().getHostAddress(), "UTF-8" ) : "";
@@ -27,5 +27,5 @@ index c52f9332..5b81eced 100644
          Callback<String> handler = new Callback<String>()
          {
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0054-Additional-DoS-mitigations.patch
+++ b/BungeeCord-Patches/0054-Additional-DoS-mitigations.patch
@@ -1,4 +1,4 @@
-From 1b3f507f9f6a92f47f6c174d57f23a516384ca03 Mon Sep 17 00:00:00 2001
+From 6bd1101b6ea32c12601623bde3a9a86ec296fa84 Mon Sep 17 00:00:00 2001
 From: "Five (Xer)" <admin@fivepb.me>
 Date: Sat, 30 Jan 2021 18:04:14 +0100
 Subject: [PATCH] Additional DoS mitigations
@@ -8,10 +8,10 @@ Courtesy of Tux and the Velocity Contributors. See:
 https://github.com/VelocityPowered/Velocity/commit/5ceac16a821ea35572ff11412ace8929fd06e278
 
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
-index 02d39adf..769ca9df 100644
+index 17490208..7fa1a5e6 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/DefinedPacket.java
-@@ -92,6 +92,7 @@ public abstract class DefinedPacket
+@@ -91,6 +91,7 @@ public abstract class DefinedPacket
          int len = readVarInt( buf );
          if ( len > maxLen * 3 )
          {
@@ -19,7 +19,7 @@ index 02d39adf..769ca9df 100644
              throw new OverflowPacketException( "Cannot receive string longer than " + maxLen * 3 + " (got " + len + " bytes)" );
          }
  
-@@ -100,6 +101,7 @@ public abstract class DefinedPacket
+@@ -99,6 +100,7 @@ public abstract class DefinedPacket
  
          if ( s.length() > maxLen )
          {
@@ -27,7 +27,7 @@ index 02d39adf..769ca9df 100644
              throw new OverflowPacketException( "Cannot receive string longer than " + maxLen + " (got " + s.length() + " characters)" );
          }
  
-@@ -602,4 +604,21 @@ public abstract class DefinedPacket
+@@ -601,4 +603,21 @@ public abstract class DefinedPacket
  
      @Override
      public abstract String toString();
@@ -257,5 +257,5 @@ index 738f0c92..ec33d337 100644
 +    // Waterfall end
  }
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0054-Additional-DoS-mitigations.patch
+++ b/BungeeCord-Patches/0054-Additional-DoS-mitigations.patch
@@ -1,4 +1,4 @@
-From 6bd1101b6ea32c12601623bde3a9a86ec296fa84 Mon Sep 17 00:00:00 2001
+From 47e697a83ed482b0a8a6d08605f9c63978461068 Mon Sep 17 00:00:00 2001
 From: "Five (Xer)" <admin@fivepb.me>
 Date: Sat, 30 Jan 2021 18:04:14 +0100
 Subject: [PATCH] Additional DoS mitigations
@@ -50,7 +50,7 @@ index 17490208..7fa1a5e6 100644
 +    // Waterfall end
  }
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
-index 52f76cd9..3a4a735c 100644
+index 7992143f..0af7d8a6 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/MinecraftDecoder.java
 @@ -3,7 +3,7 @@ package net.md_5.bungee.protocol;
@@ -62,7 +62,7 @@ index 52f76cd9..3a4a735c 100644
  import io.netty.handler.codec.MessageToMessageDecoder;
  import java.util.List;
  import lombok.AllArgsConstructor;
-@@ -58,10 +58,16 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -56,10 +56,16 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
              if ( packet != null )
              {
                  packetTypeInfo = packet.getClass();
@@ -79,7 +79,7 @@ index 52f76cd9..3a4a735c 100644
                      throw new BadPacketException( "Packet " + protocol + ":" + prot.getDirection() + "/" + packetId + " (" + packet.getClass().getSimpleName() + ") larger than expected, extra bytes: " + in.readableBytes() );
                  }
              } else
-@@ -72,6 +78,25 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -70,6 +76,25 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
              out.add( new PacketWrapper( packet, slice, protocol ) );
              slice = null;
          } catch (BadPacketException | IndexOutOfBoundsException e) {
@@ -105,7 +105,7 @@ index 52f76cd9..3a4a735c 100644
              final String packetTypeStr;
              if (packetTypeInfo instanceof Integer) {
                  packetTypeStr = "id " + Integer.toHexString((Integer) packetTypeInfo);
-@@ -81,6 +106,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+@@ -79,6 +104,7 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
                  packetTypeStr = "unknown";
              }
              throw new FastDecoderException("Error decoding packet " + packetTypeStr + " with contents:\n" + ByteBufUtil.prettyHexDump(slice), e); // Waterfall
@@ -113,11 +113,11 @@ index 52f76cd9..3a4a735c 100644
          } finally
          {
              if ( slice != null )
-@@ -89,4 +115,52 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
-             }
-         }
+@@ -100,4 +126,52 @@ public class MinecraftDecoder extends MessageToMessageDecoder<ByteBuf>
+         // EntityMap is removed for 1.20.2 and up
+         return protocol == Protocol.GAME && protocolVersion < ProtocolConstants.MINECRAFT_1_20_2;
      }
-+
++    
 +    // Waterfall start: Additional DoS mitigations, courtesy of Velocity
 +    public static final boolean DEBUG = Boolean.getBoolean("waterfall.packet-decode-logging");
 +

--- a/BungeeCord-Patches/0056-Configurable-plugin-messaging-limits.patch
+++ b/BungeeCord-Patches/0056-Configurable-plugin-messaging-limits.patch
@@ -1,4 +1,4 @@
-From 5d5b3e409c1f353512bc912b22a44040f5720dc3 Mon Sep 17 00:00:00 2001
+From dc3673581bb866d5c18ab2cd6388add4e119bb8b Mon Sep 17 00:00:00 2001
 From: FivePB <admin@fivepb.me>
 Date: Tue, 16 Nov 2021 21:15:32 +0100
 Subject: [PATCH] Configurable plugin messaging limits
@@ -83,10 +83,10 @@ index b88e3c8a..da0efa36 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 5b81eced..315d67f2 100644
+index 9149e329..4b0cdadb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -841,9 +841,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -840,9 +840,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
  
              for ( String id : content.split( "\0" ) )
              {
@@ -101,5 +101,5 @@ index 5b81eced..315d67f2 100644
              }
          } else if ( input.getTag().equals( "UNREGISTER" ) || input.getTag().equals( "minecraft:unregister" ) )
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0056-Configurable-plugin-messaging-limits.patch
+++ b/BungeeCord-Patches/0056-Configurable-plugin-messaging-limits.patch
@@ -1,4 +1,4 @@
-From dc3673581bb866d5c18ab2cd6388add4e119bb8b Mon Sep 17 00:00:00 2001
+From 7e6596f471e04c1c72a2658f9207262a38e1da8f Mon Sep 17 00:00:00 2001
 From: FivePB <admin@fivepb.me>
 Date: Tue, 16 Nov 2021 21:15:32 +0100
 Subject: [PATCH] Configurable plugin messaging limits
@@ -83,10 +83,10 @@ index b88e3c8a..da0efa36 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 9149e329..4b0cdadb 100644
+index 16cc5ff4..ddcf61fb 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -840,9 +840,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -843,9 +843,10 @@ public class InitialHandler extends PacketHandler implements PendingConnection
  
              for ( String id : content.split( "\0" ) )
              {

--- a/BungeeCord-Patches/0057-ServerConnectRequest-sendFeedback.patch
+++ b/BungeeCord-Patches/0057-ServerConnectRequest-sendFeedback.patch
@@ -1,4 +1,4 @@
-From 3da6fce027a6bbd6418951e4193883d42d8038a3 Mon Sep 17 00:00:00 2001
+From 5def70cd7ed51204fe8a101ce312fd495f57399d Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Fri, 16 Apr 2021 06:29:28 +0100
 Subject: [PATCH] ServerConnectRequest#sendFeedback
@@ -31,10 +31,10 @@ index c81b0a4e..d21370be 100644
      }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 372b95e1..c4e68d57 100644
+index fda671ec..4cfdbab1 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -322,12 +322,16 @@ public final class UserConnection implements ProxiedPlayer
+@@ -326,12 +326,16 @@ public final class UserConnection implements ProxiedPlayer
          connect(info, callback, retry, ServerConnectEvent.Reason.PLUGIN, timeout);
      }
  
@@ -53,7 +53,7 @@ index 372b95e1..c4e68d57 100644
          builder.connectTimeout(timeout); // Waterfall
          if ( callback != null )
          {
-@@ -376,7 +380,7 @@ public final class UserConnection implements ProxiedPlayer
+@@ -380,7 +384,7 @@ public final class UserConnection implements ProxiedPlayer
                  callback.done( ServerConnectRequest.Result.ALREADY_CONNECTED, null );
              }
  
@@ -62,7 +62,7 @@ index 372b95e1..c4e68d57 100644
              return;
          }
          if ( pendingConnects.contains( target ) )
-@@ -386,7 +390,7 @@ public final class UserConnection implements ProxiedPlayer
+@@ -390,7 +394,7 @@ public final class UserConnection implements ProxiedPlayer
                  callback.done( ServerConnectRequest.Result.ALREADY_CONNECTING, null );
              }
  
@@ -71,7 +71,7 @@ index 372b95e1..c4e68d57 100644
              return;
          }
  
-@@ -411,14 +415,14 @@ public final class UserConnection implements ProxiedPlayer
+@@ -415,14 +419,14 @@ public final class UserConnection implements ProxiedPlayer
                      ServerInfo def = updateAndGetNextServer( target );
                      if ( request.isRetry() && def != null && ( getServer() == null || def != getServer().getInfo() ) )
                      {
@@ -90,5 +90,5 @@ index 372b95e1..c4e68d57 100644
                  } else
                  {
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0058-Don-t-send-exceptions-to-the-client-during-kicks-etc.patch
+++ b/BungeeCord-Patches/0058-Don-t-send-exceptions-to-the-client-during-kicks-etc.patch
@@ -1,4 +1,4 @@
-From d6511444d1f2ae468df033fa221d28a943d824f0 Mon Sep 17 00:00:00 2001
+From d2c8364a36eb9e8250579eaf3b1f782a842f826a Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Tue, 22 Mar 2022 14:56:44 +0000
 Subject: [PATCH] Don't send exceptions to the client during kicks, etc
@@ -13,10 +13,10 @@ allows for retaining much of the overall context here, i.e. who
 was this exception assocated with?
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index c4e68d57..0249dc52 100644
+index 4cfdbab1..57883143 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -446,7 +446,8 @@ public final class UserConnection implements ProxiedPlayer
+@@ -450,7 +450,8 @@ public final class UserConnection implements ProxiedPlayer
  
      private String connectionFailMessage(Throwable cause)
      {
@@ -27,5 +27,5 @@ index c4e68d57..0249dc52 100644
  
      @Override
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0059-Improve-login-state-transition.patch
+++ b/BungeeCord-Patches/0059-Improve-login-state-transition.patch
@@ -1,14 +1,14 @@
-From 5ab447fe4168894bccbd238d000b2f7b483bc3eb Mon Sep 17 00:00:00 2001
+From 0fda45793477b90c98ab5ec72d01cd6ba1591178 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 8 May 2022 12:04:30 +0100
 Subject: [PATCH] Improve login state transition
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 4b0cdadb..f741e7ed 100644
+index ddcf61fb..c40cad3d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -512,6 +512,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -515,6 +515,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      {
          Preconditions.checkState( thisState == State.ENCRYPT, "Not expecting ENCRYPT" );
          Preconditions.checkState( EncryptionUtil.check( loginRequest.getPublicKey(), encryptResponse, request ), "Invalid verification" );
@@ -16,7 +16,7 @@ index 4b0cdadb..f741e7ed 100644
  
          SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );
          // Waterfall start
-@@ -568,7 +569,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -571,7 +572,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                  }
              }
          };

--- a/BungeeCord-Patches/0059-Improve-login-state-transition.patch
+++ b/BungeeCord-Patches/0059-Improve-login-state-transition.patch
@@ -1,14 +1,14 @@
-From 513794c0257b1a3aa4beebae9984480ac213aa51 Mon Sep 17 00:00:00 2001
+From 5ab447fe4168894bccbd238d000b2f7b483bc3eb Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 8 May 2022 12:04:30 +0100
 Subject: [PATCH] Improve login state transition
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 315d67f2..93952044 100644
+index 4b0cdadb..f741e7ed 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -513,6 +513,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -512,6 +512,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
      {
          Preconditions.checkState( thisState == State.ENCRYPT, "Not expecting ENCRYPT" );
          Preconditions.checkState( EncryptionUtil.check( loginRequest.getPublicKey(), encryptResponse, request ), "Invalid verification" );
@@ -16,7 +16,7 @@ index 315d67f2..93952044 100644
  
          SecretKey sharedKey = EncryptionUtil.getSecret( encryptResponse, request );
          // Waterfall start
-@@ -569,7 +570,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -568,7 +569,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
                  }
              }
          };
@@ -26,5 +26,5 @@ index 315d67f2..93952044 100644
      }
  
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0062-Add-message-for-outdated-clients-that-don-t-support-.patch
+++ b/BungeeCord-Patches/0062-Add-message-for-outdated-clients-that-don-t-support-.patch
@@ -1,4 +1,4 @@
-From fb5662cec36f3364f4a7cb07599efcc63bb156dd Mon Sep 17 00:00:00 2001
+From 2ab6e5f896f20740891d0adfe43e969a74cface2 Mon Sep 17 00:00:00 2001
 From: Aurora <aurora@relanet.eu>
 Date: Mon, 18 Jul 2022 15:56:05 +0200
 Subject: [PATCH] Add message for outdated clients that don't support secure
@@ -8,10 +8,10 @@ Clients before 1.19 don't support secure profiles, but since secure profiles is 
 things checked those outdated clients didn't get a useful message telling them to update.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index f741e7ed..ab2b55f3 100644
+index c40cad3d..8d7fb51d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -439,6 +439,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -442,6 +442,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
  
          if ( BungeeCord.getInstance().config.isEnforceSecureProfile() && getVersion() < ProtocolConstants.MINECRAFT_1_19_3 )
          {

--- a/BungeeCord-Patches/0062-Add-message-for-outdated-clients-that-don-t-support-.patch
+++ b/BungeeCord-Patches/0062-Add-message-for-outdated-clients-that-don-t-support-.patch
@@ -1,4 +1,4 @@
-From e3f93f26ca1b3177cefe5f013bf8d6ec0b8c5416 Mon Sep 17 00:00:00 2001
+From fb5662cec36f3364f4a7cb07599efcc63bb156dd Mon Sep 17 00:00:00 2001
 From: Aurora <aurora@relanet.eu>
 Date: Mon, 18 Jul 2022 15:56:05 +0200
 Subject: [PATCH] Add message for outdated clients that don't support secure
@@ -8,10 +8,10 @@ Clients before 1.19 don't support secure profiles, but since secure profiles is 
 things checked those outdated clients didn't get a useful message telling them to update.
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index 93952044..b5cd0796 100644
+index f741e7ed..ab2b55f3 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -440,6 +440,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -439,6 +439,7 @@ public class InitialHandler extends PacketHandler implements PendingConnection
  
          if ( BungeeCord.getInstance().config.isEnforceSecureProfile() && getVersion() < ProtocolConstants.MINECRAFT_1_19_3 )
          {
@@ -32,5 +32,5 @@ index c0a41fb0..94254c9a 100644
  error_occurred_player=\u00a7cAn error occurred while parsing your message. (Hover for details)
  error_occurred_console=\u00a7cAn error occurred while parsing your message: {0}
 -- 
-2.47.1.windows.2
+2.43.0
 

--- a/BungeeCord-Patches/0063-Replace-reflection-inside-netty-with-ChannelFactory.patch
+++ b/BungeeCord-Patches/0063-Replace-reflection-inside-netty-with-ChannelFactory.patch
@@ -1,4 +1,4 @@
-From eeb994b286298b69154248c713ad17d1902cf224 Mon Sep 17 00:00:00 2001
+From 2861c897437c561280228134d099f49fa328f293 Mon Sep 17 00:00:00 2001
 From: Janmm14 <gitconfig1@janmm14.de>
 Date: Mon, 21 Jun 2021 23:43:39 +0200
 Subject: [PATCH] Replace reflection inside netty with ChannelFactory.
@@ -6,10 +6,10 @@ Subject: [PATCH] Replace reflection inside netty with ChannelFactory.
 Thanks for pointing it out @MrIvanPlays
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-index 27988fd5..2222791d 100644
+index bdd8565c..4dbf3df9 100644
 --- a/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
 +++ b/proxy/src/main/java/net/md_5/bungee/BungeeCord.java
-@@ -377,7 +377,7 @@ public class BungeeCord extends ProxyServer
+@@ -351,7 +351,7 @@ public class BungeeCord extends ProxyServer
                  }
              };
              new ServerBootstrap()
@@ -32,10 +32,10 @@ index 0d24f1eb..0ce7b343 100644
                  .handler( ProxyServer.getInstance().unsafe().getServerInfoChannelInitializer().getChannelInitializer() )
                  .option( ChannelOption.CONNECT_TIMEOUT_MILLIS, BungeeCord.getInstance().getConfig().getRemotePingTimeout() )
 diff --git a/proxy/src/main/java/net/md_5/bungee/UserConnection.java b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-index 0249dc52..ea53cf42 100644
+index 57883143..971593f4 100644
 --- a/proxy/src/main/java/net/md_5/bungee/UserConnection.java
 +++ b/proxy/src/main/java/net/md_5/bungee/UserConnection.java
-@@ -431,7 +431,7 @@ public final class UserConnection implements ProxiedPlayer
+@@ -435,7 +435,7 @@ public final class UserConnection implements ProxiedPlayer
              }
          };
          Bootstrap b = new Bootstrap()
@@ -69,7 +69,7 @@ index 37337429..c3683c30 100644
      }
      // Waterfall End
 diff --git a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
-index b8b4b23c..1899bd75 100644
+index bd40e88c..850d4c4d 100644
 --- a/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 +++ b/proxy/src/main/java/net/md_5/bungee/netty/PipelineUtils.java
 @@ -5,6 +5,8 @@ import io.github.waterfallmc.waterfall.event.ConnectionInitEvent;
@@ -80,8 +80,8 @@ index b8b4b23c..1899bd75 100644
 +import io.netty.channel.ChannelInitializer;
  import io.netty.channel.ChannelOption;
  import io.netty.channel.EventLoopGroup;
- import io.netty.channel.ServerChannel;
-@@ -148,6 +150,12 @@ public class PipelineUtils
+ import io.netty.channel.MultiThreadIoEventLoopGroup;
+@@ -149,6 +151,12 @@ public class PipelineUtils
  
      private static boolean epoll;
      private static boolean io_uring;
@@ -94,21 +94,21 @@ index b8b4b23c..1899bd75 100644
  
      static
      {
-@@ -180,6 +188,12 @@ public class PipelineUtils
+@@ -182,6 +190,12 @@ public class PipelineUtils
          }
  
          setChannelInitializerHolders();
 +        // Waterfall start: netty reflection -> factory
-+        serverChannelFactory = io_uring ? IOUringServerSocketChannel::new : epoll ? EpollServerSocketChannel::new : NioServerSocketChannel::new;
-+        serverChannelDomainFactory = io_uring ? IOUringServerSocketChannel::new : epoll ? EpollServerDomainSocketChannel::new : null;
-+        channelFactory = io_uring ? IOUringSocketChannel::new : epoll ? EpollSocketChannel::new : NioSocketChannel::new;
-+        channelDomainFactory = io_uring ? IOUringSocketChannel::new : epoll ? EpollDomainSocketChannel::new : null;
++        serverChannelFactory = io_uring ? IoUringServerSocketChannel::new : epoll ? EpollServerSocketChannel::new : NioServerSocketChannel::new;
++        serverChannelDomainFactory = io_uring ? IoUringServerSocketChannel::new : epoll ? EpollServerDomainSocketChannel::new : null;
++        channelFactory = io_uring ? IoUringServerSocketChannel::new : epoll ? EpollSocketChannel::new : NioSocketChannel::new;
++        channelDomainFactory = io_uring ? IoUringServerSocketChannel::new : epoll ? EpollDomainSocketChannel::new : null;
 +        // Waterfall end
      }
  
      public static EventLoopGroup newEventLoopGroup(int threads, ThreadFactory factory)
-@@ -211,6 +225,34 @@ public class PipelineUtils
-         return io_uring ? IOUringSocketChannel.class : epoll ? EpollSocketChannel.class : NioSocketChannel.class;
+@@ -213,6 +227,34 @@ public class PipelineUtils
+         return io_uring ? IoUringSocketChannel.class : epoll ? EpollSocketChannel.class : NioSocketChannel.class;
      }
  
 +    // Waterfall start: netty reflection -> factory
@@ -141,7 +141,7 @@ index b8b4b23c..1899bd75 100644
 +
      public static Class<? extends DatagramChannel> getDatagramChannel()
      {
-         return io_uring ? IOUringDatagramChannel.class : epoll ? EpollDatagramChannel.class : NioDatagramChannel.class;
+         return io_uring ? IoUringDatagramChannel.class : epoll ? EpollDatagramChannel.class : NioDatagramChannel.class;
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0064-reduce-log-spam-from-clients-registeirng-too-many-ch.patch
+++ b/BungeeCord-Patches/0064-reduce-log-spam-from-clients-registeirng-too-many-ch.patch
@@ -1,14 +1,14 @@
-From 7dd2e2bfd0339e12a2a8ea29240300de81b9ff10 Mon Sep 17 00:00:00 2001
+From 4ca3fa58018fd90b8f24adfaaf2825fba015a8c2 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Fri, 21 Apr 2023 15:32:33 +0100
 Subject: [PATCH] reduce log spam from clients registeirng too many channels
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index ab2b55f3..a2686cfa 100644
+index 8d7fb51d..294860ed 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -198,6 +198,22 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -201,6 +201,22 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          }
      }
  

--- a/BungeeCord-Patches/0064-reduce-log-spam-from-clients-registeirng-too-many-ch.patch
+++ b/BungeeCord-Patches/0064-reduce-log-spam-from-clients-registeirng-too-many-ch.patch
@@ -1,14 +1,14 @@
-From 35620ec04456233dbe33f5f1397b9c8ed403c89e Mon Sep 17 00:00:00 2001
+From 7dd2e2bfd0339e12a2a8ea29240300de81b9ff10 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Fri, 21 Apr 2023 15:32:33 +0100
 Subject: [PATCH] reduce log spam from clients registeirng too many channels
 
 
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-index e18d288a..9ed724b7 100644
+index ab2b55f3..a2686cfa 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/InitialHandler.java
-@@ -199,6 +199,22 @@ public class InitialHandler extends PacketHandler implements PendingConnection
+@@ -198,6 +198,22 @@ public class InitialHandler extends PacketHandler implements PendingConnection
          }
      }
  
@@ -32,5 +32,5 @@ index e18d288a..9ed724b7 100644
      public void handle(LegacyHandshake legacyHandshake) throws Exception
      {
 -- 
-2.49.0
+2.43.0
 

--- a/BungeeCord-Patches/0065-Prevent-proxy-commands-from-breaking-the-chat-chain-.patch
+++ b/BungeeCord-Patches/0065-Prevent-proxy-commands-from-breaking-the-chat-chain-.patch
@@ -1,4 +1,4 @@
-From e162151ab133b64201819158705898b6660f7136 Mon Sep 17 00:00:00 2001
+From 20254bb0f421a3ae5a957117a208b7d3ef48f0ce Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 15 Oct 2023 00:36:38 +0100
 Subject: [PATCH] Prevent proxy commands from breaking the chat chain system
@@ -90,10 +90,10 @@ index f86fcd08..40df53fe 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-index a6176702..3e583f51 100644
+index 459aff6d..c3fd80c5 100644
 --- a/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
 +++ b/proxy/src/main/java/net/md_5/bungee/connection/UpstreamBridge.java
-@@ -198,16 +198,22 @@ public class UpstreamBridge extends PacketHandler
+@@ -197,16 +197,22 @@ public class UpstreamBridge extends PacketHandler
      @Override
      public void handle(ClientCommand command) throws Exception
      {
@@ -118,7 +118,7 @@ index a6176702..3e583f51 100644
      {
          for ( int index = 0, length = message.length(); index < length; index++ )
          {
-@@ -226,7 +232,13 @@ public class UpstreamBridge extends PacketHandler
+@@ -225,7 +231,13 @@ public class UpstreamBridge extends PacketHandler
              if ( !chatEvent.isCommand() || !bungee.getPluginManager().dispatchCommand( con, message.substring( 1 ) ) )
              {
                  return message;
@@ -133,5 +133,5 @@ index a6176702..3e583f51 100644
          throw CancelSendSignal.INSTANCE;
      }
 -- 
-2.49.0
+2.43.0
 


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly. This update has not been tested by PaperMC and as with ANY update, please do your own testing

BungeeCord Changes:
d81040cd Bump lombok version
d7538df9 #3815: Ensure ping response for unthrottling 2516de65 #3816: Upgrade Netty to 4.2.0.Final
1da3a8c2 #3814: Fire exception in pipeline if async task in eventloop throws exception f6151dce Bump version to 1.21-R0.3-SNAPSHOT
96677437 Release 1.21-R0.2
7587f033 SPIGOT-8024, #3811, #3812: Add versioned chat serialization (beta)