### PR TITLE
Use the proxy's online mode state on entity-metadata-rewrite server switches

### DIFF
--- a/BungeeCord-Patches/0043-Provide-an-option-to-disable-entity-metadata-rewriti.patch
+++ b/BungeeCord-Patches/0043-Provide-an-option-to-disable-entity-metadata-rewriti.patch
@@ -1,4 +1,4 @@
-From d11fb0a8e5b920353c086c716f2cbd5a4f06b1cb Mon Sep 17 00:00:00 2001
+From 8a74d6c9d80c7b7639a3746b1bd88c8cbfea6662 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Mon, 14 Jan 2019 03:35:21 +0000
 Subject: [PATCH] Provide an option to disable entity metadata rewriting
@@ -57,7 +57,7 @@ index 4ff8da6d..e860214f 100644
 +    }
  }
 diff --git a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
-index 0340226e..0b49fcb2 100644
+index 9dbcd605..dab161a6 100644
 --- a/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 +++ b/proxy/src/main/java/net/md_5/bungee/ServerConnector.java
 @@ -335,6 +335,7 @@ public class ServerConnector extends PacketHandler
@@ -100,7 +100,7 @@ index 0340226e..0b49fcb2 100644
 +                }
 +                Login modLogin = new Login( login.getEntityId(), login.isHardcore(), login.getGameMode(), login.getPreviousGameMode(), login.getWorldNames(), login.getDimensions(), login.getDimension(), login.getWorldName(), login.getSeed(), login.getDifficulty(),
 +                        (byte) user.getPendingConnection().getListener().getTabListSize(), login.getLevelType(), login.getViewDistance(), login.getSimulationDistance(), login.isReducedDebugInfo(), login.isNormalRespawn(), login.isLimitedCrafting(), login.isDebug(), login.isFlat(), login.getDeathLocation(),
-+                        login.getPortalCooldown(), login.getSeaLevel(), login.isOnlineMode(), login.isSecureProfile() );
++                        login.getPortalCooldown(), login.getSeaLevel(), user.getPendingConnection().isOnlineMode(), login.isSecureProfile() ); // Waterfall - report this connection's online mode (authenticated by the proxy) so the client prepares chat keys correctly, rather than the backend's value
 +                user.unsafe().sendPacket(modLogin);
 +                // Only send if we're in the same dimension
 +                if ( login.getDimension() == user.getDimension() ) // Waterfall - defer
@@ -216,5 +216,5 @@ index 00000000..cb81d1dd
 +// Waterfall end
 \ No newline at end of file
 -- 
-2.54.0
+2.43.0
 


### PR DESCRIPTION
Upstream #3998 (`dc538cb2`) took the initial-login half of our temporary "Use proxy online mode state" patch, so that patch was dropped in the last upstream update (#874). Its other half applied to our own code, not upstream's: the `Login` packet that the `disable_entity_metadata_rewrite` path re-sends on a server switch, in `0043-Provide-an-option-to-disable-entity-metadata-rewriti.patch`. That line went back to reporting the backend's `login.isOnlineMode()`.

With an online-mode proxy in front of offline-mode backends, the client is told `true` at login (upstream's site) and `false` on every switch through that path, so it does not prepare chat keys consistently. Only installs running with entity metadata rewriting disabled are affected; the default path sends a `Respawn` and never hit this.

This reports `user.getPendingConnection().isOnlineMode()` at that site too, restoring the comment explaining why.

Patches apply cleanly and `./waterfall b` builds green on JDK 21. (The build fails on this machine's JDK 25 with `release version 17 not supported` — pre-existing and unrelated to this change.)