### PR TITLE
Temp: 26.3-rc-1 protocol support

### DIFF
--- a/BungeeCord-Patches/0069-Temp-26.3-rc-1-protocol-support.patch
+++ b/BungeeCord-Patches/0069-Temp-26.3-rc-1-protocol-support.patch
@@ -1,21 +1,21 @@
-From 0575950aa506138ce0ceac64e2f0a47f1cac17f8 Mon Sep 17 00:00:00 2001
+From e5112843f617a4b5b5bc3c7de5641c45906e59cd Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Fri, 4 Sep 2026 22:24:49 +0200
-Subject: [PATCH] Temp: 26.3-pre-3 protocol support
+Subject: [PATCH] Temp: 26.3-rc-1 protocol support
 
 Adds MINECRAFT_26_3 behind the existing net.md_5.bungee.protocol.snapshot
-flag, using the snapshot protocol number (0x40000000 | 335) as upstream does
+flag, using the snapshot protocol number (0x40000000 | 336) as upstream does
 during a pre-release cycle, and remaps the packets whose ids moved.
 
 Relative to 26.2, 26.3 inserts post_effects into both the configuration and
-game clientbound tables, swing_animation into the game clientbound table, and,
-as of pre-3, add_transient_block at game clientbound 0x25. That last one sits
-low enough to shift almost the whole table, so 25 of the game clientbound
-packets we register move, on top of the 7 configuration ones. Serverbound is
-unaffected for us, as the punch/swing shuffle sits in the 0x2E-0x3F window we
-do not register in, and CustomClickAction at 0x44 is above it. Every id was
-checked against the registration order in GameProtocols and
-ConfigurationProtocols rather than the protocol summary.
+game clientbound tables, swing_animation into the game clientbound table, and
+add_transient_block at game clientbound 0x25. That last one sits low enough to
+shift almost the whole table, so 25 of the game clientbound packets we register
+move, on top of the 7 configuration ones. Serverbound is unaffected for us, as
+the punch/swing shuffle sits in the 0x2E-0x3F window we do not register in, and
+CustomClickAction at 0x44 is above it. Every id was checked against the
+registration order in GameProtocols and ConfigurationProtocols rather than the
+protocol summary.
 
 CommonPlayerSpawnInfo, which Login and Respawn both embed, is the one packet
 payload change. gameType moved from a byte to a var int, and previousGameType
@@ -35,6 +35,10 @@ backend throws ArrayIndexOutOfBoundsException. 26.3 likewise adds a
 post_effects suggestion provider; those are keyed by name rather than index
 and unknown names are rejected outright, so it is registered as a dummy for
 every version.
+
+rc-1 is a protocol number bump only: nothing under network/ changed between
+pre-3 and rc-1, and the argument type and suggestion provider registries are
+untouched, so only the constant moves.
 
 This is temporary and should be dropped once upstream adds 26.3 support.
 
@@ -374,14 +378,14 @@ index b6779092..896466ec 100644
  
              TO_SERVER.registerPacket(
 diff --git a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
-index 31d04a0e..089a56ee 100644
+index 31d04a0e..98c607cb 100644
 --- a/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
 +++ b/protocol/src/main/java/net/md_5/bungee/protocol/ProtocolConstants.java
 @@ -56,6 +56,7 @@ public class ProtocolConstants
      public static final int MINECRAFT_1_21_11 = 774;
      public static final int MINECRAFT_26_1 = 775;
      public static final int MINECRAFT_26_2 = 776;
-+    public static final int MINECRAFT_26_3 = 1073742159;
++    public static final int MINECRAFT_26_3 = 1073742160;
      public static final List<String> SUPPORTED_VERSIONS;
      public static final List<Integer> SUPPORTED_VERSION_IDS;
  


### PR DESCRIPTION
Moves the temporary 26.3 protocol patch from pre-3 to rc-1.

`MINECRAFT_26_3` becomes `1073742160` (`0x40000000 | 336`), following upstream's convention of bumping the existing constant's value through a pre-release cycle rather than adding a new one, so only one snapshot version is live at a time.

### rc-1 is a protocol number bump and nothing else

Diffed the decompiled sources for `26.3-pre-3` against `26.3-rc-1`:

- `SNAPSHOT_NETWORK_PROTOCOL_VERSION` 335 → 336, `WORLD_VERSION` 5019 → 5020
- **nothing under `src/main/java/net/minecraft/network/` changed** — no packet added, removed, renumbered, or re-payloaded
- `GameProtocols.java` / `ConfigurationProtocols.java` — untouched
- `ArgumentTypeInfos.java` / `SuggestionProviders.java` — untouched, so neither of the registries that broke on the 26.2 → 26.3 jump grew this time

The rest of the release diff is gameplay and client internals (`LivingEntity`, `Ravager`, `ChunkMap`, `LevelExtractor`, loot predicates) plus `version.json`.

So the only code hunk in the regenerated patch is the constant:

```diff
-    public static final int MINECRAFT_26_3 = 1073742159;
+    public static final int MINECRAFT_26_3 = 1073742160;
```

### This supersedes the pre-3 patch, it does not sit beside it

The commit is a single-file **rename** (`R096`): `0069-Temp-26.3-pre-3-protocol-support.patch` → `0069-Temp-26.3-rc-1-protocol-support.patch`. The number stays `0069` so it remains after #877's `0067`/`0068`.

Worth flagging at merge time: #878 was the same shape — a rename of this same temp patch — and because its base had drifted it merged as an *add*, leaving the superseded file behind and producing the duplicate numbering that #879 had to fix. This branch is currently exactly one commit on top of `master` with no drift. If anything lands before it merges, regenerate rather than letting the rename be auto-resolved, and afterwards confirm only one temp patch survived:

```
git ls-tree --name-only origin/master BungeeCord-Patches/ | grep Temp
```

### Testing

Patch applies cleanly from scratch; full build and test suite pass. Smoke tested against a live proxy driven at the protocol level with fake rc-1 backends:

- status ping at `1073742160` → accepted, `26.3.x` advertised
- status ping at `1073742159` (pre-3) → correctly rejected, confirming the in-place constant bump
- full login plus a server switch → `Login 0x32`, `StartConfiguration 0x78`, second `Login 0x32`, `Respawn 0x54`, all decoding at the expected ids with `previousGameMode` present and intact (2 and 3) and every parsed packet consuming its payload exactly
- no exceptions or decode errors in the proxy log

Packet ids needed no changes, which is the expected result given the empty `network/` diff.
